### PR TITLE
M0: error and command type foundations

### DIFF
--- a/crates/libairspy/src/commands.rs
+++ b/crates/libairspy/src/commands.rs
@@ -1,0 +1,297 @@
+//! Wire-level constants and enums shared with the Airspy firmware,
+//! transcribed from `airspy_commands.h` and `airspy.h`.
+//!
+//! Every discriminant here crosses the USB wire — values must match the
+//! C headers exactly (enforced by the tests at the bottom).
+
+/// `AIRSPY_CMD_MAX` — highest vendor-request value.
+pub const CMD_MAX: u8 = 27;
+
+/// `AIRSPY_CONF_CMD_SHIFT_BIT` — the samplerate-configuration commands
+/// pack extra flags above this many bits of samplerate index (up to
+/// 8 samplerates).
+pub const CONF_CMD_SHIFT_BIT: u8 = 3;
+
+/// USB vendor requests shared between firmware and host
+/// (`airspy_vendor_request`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Command {
+    /// `AIRSPY_INVALID`
+    Invalid = 0,
+    /// `AIRSPY_RECEIVER_MODE`
+    ReceiverMode = 1,
+    /// `AIRSPY_SI5351C_WRITE`
+    Si5351cWrite = 2,
+    /// `AIRSPY_SI5351C_READ`
+    Si5351cRead = 3,
+    /// `AIRSPY_R820T_WRITE`
+    R820tWrite = 4,
+    /// `AIRSPY_R820T_READ`
+    R820tRead = 5,
+    /// `AIRSPY_SPIFLASH_ERASE`
+    SpiflashErase = 6,
+    /// `AIRSPY_SPIFLASH_WRITE`
+    SpiflashWrite = 7,
+    /// `AIRSPY_SPIFLASH_READ`
+    SpiflashRead = 8,
+    /// `AIRSPY_BOARD_ID_READ`
+    BoardIdRead = 9,
+    /// `AIRSPY_VERSION_STRING_READ`
+    VersionStringRead = 10,
+    /// `AIRSPY_BOARD_PARTID_SERIALNO_READ`
+    BoardPartIdSerialNoRead = 11,
+    /// `AIRSPY_SET_SAMPLERATE`
+    SetSamplerate = 12,
+    /// `AIRSPY_SET_FREQ`
+    SetFreq = 13,
+    /// `AIRSPY_SET_LNA_GAIN`
+    SetLnaGain = 14,
+    /// `AIRSPY_SET_MIXER_GAIN`
+    SetMixerGain = 15,
+    /// `AIRSPY_SET_VGA_GAIN`
+    SetVgaGain = 16,
+    /// `AIRSPY_SET_LNA_AGC`
+    SetLnaAgc = 17,
+    /// `AIRSPY_SET_MIXER_AGC`
+    SetMixerAgc = 18,
+    /// `AIRSPY_MS_VENDOR_CMD`
+    MsVendorCmd = 19,
+    /// `AIRSPY_SET_RF_BIAS_CMD`
+    SetRfBias = 20,
+    /// `AIRSPY_GPIO_WRITE`
+    GpioWrite = 21,
+    /// `AIRSPY_GPIO_READ`
+    GpioRead = 22,
+    /// `AIRSPY_GPIODIR_WRITE`
+    GpiodirWrite = 23,
+    /// `AIRSPY_GPIODIR_READ`
+    GpiodirRead = 24,
+    /// `AIRSPY_GET_SAMPLERATES`
+    GetSamplerates = 25,
+    /// `AIRSPY_SET_PACKING`
+    SetPacking = 26,
+    /// `AIRSPY_SPIFLASH_ERASE_SECTOR` (`= AIRSPY_CMD_MAX`)
+    SpiflashEraseSector = 27,
+}
+
+/// Receiver mode (`receiver_mode_t`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ReceiverMode {
+    /// `RECEIVER_MODE_OFF`
+    Off = 0,
+    /// `RECEIVER_MODE_RX`
+    Rx = 1,
+}
+
+/// Output sample format (`enum airspy_sample_type`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SampleType {
+    /// `AIRSPY_SAMPLE_FLOAT32_IQ` — 2 × 32-bit float per sample
+    Float32Iq = 0,
+    /// `AIRSPY_SAMPLE_FLOAT32_REAL` — 1 × 32-bit float per sample
+    Float32Real = 1,
+    /// `AIRSPY_SAMPLE_INT16_IQ` — 2 × 16-bit int per sample
+    Int16Iq = 2,
+    /// `AIRSPY_SAMPLE_INT16_REAL` — 1 × 16-bit int per sample
+    Int16Real = 3,
+    /// `AIRSPY_SAMPLE_UINT16_REAL` — 1 × 16-bit unsigned int per sample
+    Uint16Real = 4,
+    /// `AIRSPY_SAMPLE_RAW` — raw packed samples from the device
+    Raw = 5,
+}
+
+impl SampleType {
+    /// Number of supported sample types (`AIRSPY_SAMPLE_END`).
+    pub const COUNT: u8 = 6;
+}
+
+/// Board identifier (`enum airspy_board_id`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum BoardId {
+    /// `AIRSPY_BOARD_ID_PROTO_AIRSPY`
+    ProtoAirspy = 0,
+    /// `AIRSPY_BOARD_ID_INVALID`
+    Invalid = 0xFF,
+}
+
+impl BoardId {
+    /// Decode a board id byte read from the device. Returns `None` for
+    /// values the C library would print as "Unknown Board ID".
+    #[must_use]
+    pub const fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(Self::ProtoAirspy),
+            0xFF => Some(Self::Invalid),
+            _ => None,
+        }
+    }
+
+    /// The display name, exactly as `airspy_board_id_name()` returns it.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::ProtoAirspy => "AIRSPY",
+            Self::Invalid => "Invalid Board ID",
+        }
+    }
+}
+
+/// GPIO port (`airspy_gpio_port_t`), ports 0–7.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+#[allow(missing_docs)]
+pub enum GpioPort {
+    Port0 = 0,
+    Port1 = 1,
+    Port2 = 2,
+    Port3 = 3,
+    Port4 = 4,
+    Port5 = 5,
+    Port6 = 6,
+    Port7 = 7,
+}
+
+/// GPIO pin (`airspy_gpio_pin_t`), pins 0–31.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+#[allow(missing_docs)]
+pub enum GpioPin {
+    Pin0 = 0,
+    Pin1 = 1,
+    Pin2 = 2,
+    Pin3 = 3,
+    Pin4 = 4,
+    Pin5 = 5,
+    Pin6 = 6,
+    Pin7 = 7,
+    Pin8 = 8,
+    Pin9 = 9,
+    Pin10 = 10,
+    Pin11 = 11,
+    Pin12 = 12,
+    Pin13 = 13,
+    Pin14 = 14,
+    Pin15 = 15,
+    Pin16 = 16,
+    Pin17 = 17,
+    Pin18 = 18,
+    Pin19 = 19,
+    Pin20 = 20,
+    Pin21 = 21,
+    Pin22 = 22,
+    Pin23 = 23,
+    Pin24 = 24,
+    Pin25 = 25,
+    Pin26 = 26,
+    Pin27 = 27,
+    Pin28 = 28,
+    Pin29 = 29,
+    Pin30 = 30,
+    Pin31 = 31,
+}
+
+/// Device configuration page (`airspy_common_config_pages_t`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ConfigPage {
+    /// `CONFIG_CALIBRATION`
+    Calibration = 0,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vendor_request_bytes_match_c_airspy_vendor_request() {
+        // Wire compatibility with `airspy_vendor_request` in
+        // airspy_commands.h — these bytes go over USB.
+        assert_eq!(Command::Invalid as u8, 0);
+        assert_eq!(Command::ReceiverMode as u8, 1);
+        assert_eq!(Command::Si5351cWrite as u8, 2);
+        assert_eq!(Command::Si5351cRead as u8, 3);
+        assert_eq!(Command::R820tWrite as u8, 4);
+        assert_eq!(Command::R820tRead as u8, 5);
+        assert_eq!(Command::SpiflashErase as u8, 6);
+        assert_eq!(Command::SpiflashWrite as u8, 7);
+        assert_eq!(Command::SpiflashRead as u8, 8);
+        assert_eq!(Command::BoardIdRead as u8, 9);
+        assert_eq!(Command::VersionStringRead as u8, 10);
+        assert_eq!(Command::BoardPartIdSerialNoRead as u8, 11);
+        assert_eq!(Command::SetSamplerate as u8, 12);
+        assert_eq!(Command::SetFreq as u8, 13);
+        assert_eq!(Command::SetLnaGain as u8, 14);
+        assert_eq!(Command::SetMixerGain as u8, 15);
+        assert_eq!(Command::SetVgaGain as u8, 16);
+        assert_eq!(Command::SetLnaAgc as u8, 17);
+        assert_eq!(Command::SetMixerAgc as u8, 18);
+        assert_eq!(Command::MsVendorCmd as u8, 19);
+        assert_eq!(Command::SetRfBias as u8, 20);
+        assert_eq!(Command::GpioWrite as u8, 21);
+        assert_eq!(Command::GpioRead as u8, 22);
+        assert_eq!(Command::GpiodirWrite as u8, 23);
+        assert_eq!(Command::GpiodirRead as u8, 24);
+        assert_eq!(Command::GetSamplerates as u8, 25);
+        assert_eq!(Command::SetPacking as u8, 26);
+        assert_eq!(Command::SpiflashEraseSector as u8, 27);
+        assert_eq!(CMD_MAX, 27);
+    }
+
+    #[test]
+    fn samplerate_conf_shift_matches_c() {
+        // AIRSPY_CONF_CMD_SHIFT_BIT in airspy_commands.h — used to pack
+        // the packing flag alongside the samplerate index.
+        assert_eq!(CONF_CMD_SHIFT_BIT, 3);
+    }
+
+    #[test]
+    fn receiver_mode_values_match_c() {
+        assert_eq!(ReceiverMode::Off as u8, 0);
+        assert_eq!(ReceiverMode::Rx as u8, 1);
+    }
+
+    #[test]
+    fn sample_type_values_match_c_enum_airspy_sample_type() {
+        assert_eq!(SampleType::Float32Iq as u8, 0);
+        assert_eq!(SampleType::Float32Real as u8, 1);
+        assert_eq!(SampleType::Int16Iq as u8, 2);
+        assert_eq!(SampleType::Int16Real as u8, 3);
+        assert_eq!(SampleType::Uint16Real as u8, 4);
+        assert_eq!(SampleType::Raw as u8, 5);
+        assert_eq!(SampleType::COUNT, 6); // AIRSPY_SAMPLE_END
+    }
+
+    #[test]
+    fn board_id_values_and_names_match_c() {
+        assert_eq!(BoardId::ProtoAirspy as u8, 0);
+        assert_eq!(BoardId::Invalid as u8, 0xFF);
+        // Names from airspy_board_id_name() in airspy.c.
+        assert_eq!(BoardId::ProtoAirspy.name(), "AIRSPY");
+        assert_eq!(BoardId::Invalid.name(), "Invalid Board ID");
+    }
+
+    #[test]
+    fn board_id_from_u8_roundtrips_and_rejects_unknown() {
+        assert_eq!(BoardId::from_u8(0), Some(BoardId::ProtoAirspy));
+        assert_eq!(BoardId::from_u8(0xFF), Some(BoardId::Invalid));
+        assert_eq!(BoardId::from_u8(7), None);
+    }
+
+    #[test]
+    fn gpio_port_and_pin_values_match_c() {
+        assert_eq!(GpioPort::Port0 as u8, 0);
+        assert_eq!(GpioPort::Port7 as u8, 7);
+        assert_eq!(GpioPin::Pin0 as u8, 0);
+        assert_eq!(GpioPin::Pin13 as u8, 13);
+        assert_eq!(GpioPin::Pin31 as u8, 31);
+    }
+
+    #[test]
+    fn config_page_values_match_c() {
+        assert_eq!(ConfigPage::Calibration as u8, 0);
+    }
+}

--- a/crates/libairspy/src/error.rs
+++ b/crates/libairspy/src/error.rs
@@ -71,7 +71,10 @@ impl Error {
             Self::NotFound => "AIRSPY_ERROR_NOT_FOUND",
             Self::Busy => "AIRSPY_ERROR_BUSY",
             Self::NoMem => "AIRSPY_ERROR_NO_MEM",
-            Self::Unsupported => "AIRSPY_ERROR_UNSUPPORTED",
+            // AIRSPY_ERROR_UNSUPPORTED is missing from the C switch in
+            // airspy_error_name(), so C returns its default string; we
+            // replicate that for output parity with the C tools.
+            Self::Unsupported => "airspy unknown error",
             Self::Usb(_) => "AIRSPY_ERROR_LIBUSB",
             Self::Thread => "AIRSPY_ERROR_THREAD",
             Self::StreamingThread => "AIRSPY_ERROR_STREAMING_THREAD_ERR",
@@ -108,7 +111,10 @@ mod tests {
         assert_eq!(Error::NotFound.name(), "AIRSPY_ERROR_NOT_FOUND");
         assert_eq!(Error::Busy.name(), "AIRSPY_ERROR_BUSY");
         assert_eq!(Error::NoMem.name(), "AIRSPY_ERROR_NO_MEM");
-        assert_eq!(Error::Unsupported.name(), "AIRSPY_ERROR_UNSUPPORTED");
+        // AIRSPY_ERROR_UNSUPPORTED has no case in C's airspy_error_name()
+        // switch — it falls through to the default branch. C-exact means
+        // replicating that quirk.
+        assert_eq!(Error::Unsupported.name(), "airspy unknown error");
         assert_eq!(Error::Usb(rusb::Error::Io).name(), "AIRSPY_ERROR_LIBUSB");
         assert_eq!(Error::Thread.name(), "AIRSPY_ERROR_THREAD");
         assert_eq!(

--- a/crates/libairspy/src/error.rs
+++ b/crates/libairspy/src/error.rs
@@ -1,0 +1,139 @@
+//! Error type mirroring `enum airspy_error` from `airspy.h`.
+//!
+//! The C enum's two success values (`AIRSPY_SUCCESS`, `AIRSPY_TRUE`)
+//! have no counterpart here — success is `Ok` in Rust. Every error
+//! variant keeps its C integer code ([`Error::code`]) and its
+//! `airspy_error_name()` string ([`Error::name`]) so tool output stays
+//! diffable against the C tools.
+
+/// Convenience alias used across the crate.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Errors reported by the driver, mirroring `enum airspy_error`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// `AIRSPY_ERROR_INVALID_PARAM` (-2)
+    #[error("AIRSPY_ERROR_INVALID_PARAM (-2): invalid parameter")]
+    InvalidParam,
+    /// `AIRSPY_ERROR_NOT_FOUND` (-5)
+    #[error("AIRSPY_ERROR_NOT_FOUND (-5): device not found")]
+    NotFound,
+    /// `AIRSPY_ERROR_BUSY` (-6)
+    #[error("AIRSPY_ERROR_BUSY (-6): device busy")]
+    Busy,
+    /// `AIRSPY_ERROR_NO_MEM` (-11)
+    #[error("AIRSPY_ERROR_NO_MEM (-11): out of memory")]
+    NoMem,
+    /// `AIRSPY_ERROR_UNSUPPORTED` (-12)
+    #[error("AIRSPY_ERROR_UNSUPPORTED (-12): operation unsupported")]
+    Unsupported,
+    /// `AIRSPY_ERROR_LIBUSB` (-1000), carrying the underlying USB error.
+    #[error("AIRSPY_ERROR_LIBUSB (-1000): {0}")]
+    Usb(#[from] rusb::Error),
+    /// `AIRSPY_ERROR_THREAD` (-1001)
+    #[error("AIRSPY_ERROR_THREAD (-1001): worker thread failure")]
+    Thread,
+    /// `AIRSPY_ERROR_STREAMING_THREAD_ERR` (-1002)
+    #[error("AIRSPY_ERROR_STREAMING_THREAD_ERR (-1002): streaming thread failure")]
+    StreamingThread,
+    /// `AIRSPY_ERROR_STREAMING_STOPPED` (-1003)
+    #[error("AIRSPY_ERROR_STREAMING_STOPPED (-1003): streaming stopped")]
+    StreamingStopped,
+    /// `AIRSPY_ERROR_OTHER` (-9999)
+    #[error("AIRSPY_ERROR_OTHER (-9999): unspecified error")]
+    Other,
+}
+
+impl Error {
+    /// The C `enum airspy_error` integer code for this error.
+    #[must_use]
+    pub const fn code(&self) -> i32 {
+        match self {
+            Self::InvalidParam => -2,
+            Self::NotFound => -5,
+            Self::Busy => -6,
+            Self::NoMem => -11,
+            Self::Unsupported => -12,
+            Self::Usb(_) => -1000,
+            Self::Thread => -1001,
+            Self::StreamingThread => -1002,
+            Self::StreamingStopped => -1003,
+            Self::Other => -9999,
+        }
+    }
+
+    /// The constant name, exactly as `airspy_error_name()` returns it.
+    #[must_use]
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Self::InvalidParam => "AIRSPY_ERROR_INVALID_PARAM",
+            Self::NotFound => "AIRSPY_ERROR_NOT_FOUND",
+            Self::Busy => "AIRSPY_ERROR_BUSY",
+            Self::NoMem => "AIRSPY_ERROR_NO_MEM",
+            Self::Unsupported => "AIRSPY_ERROR_UNSUPPORTED",
+            Self::Usb(_) => "AIRSPY_ERROR_LIBUSB",
+            Self::Thread => "AIRSPY_ERROR_THREAD",
+            Self::StreamingThread => "AIRSPY_ERROR_STREAMING_THREAD_ERR",
+            Self::StreamingStopped => "AIRSPY_ERROR_STREAMING_STOPPED",
+            Self::Other => "AIRSPY_ERROR_OTHER",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_codes_match_c_enum_airspy_error() {
+        // Wire/ABI compatibility with `enum airspy_error` in airspy.h.
+        assert_eq!(Error::InvalidParam.code(), -2);
+        assert_eq!(Error::NotFound.code(), -5);
+        assert_eq!(Error::Busy.code(), -6);
+        assert_eq!(Error::NoMem.code(), -11);
+        assert_eq!(Error::Unsupported.code(), -12);
+        assert_eq!(Error::Usb(rusb::Error::Io).code(), -1000);
+        assert_eq!(Error::Thread.code(), -1001);
+        assert_eq!(Error::StreamingThread.code(), -1002);
+        assert_eq!(Error::StreamingStopped.code(), -1003);
+        assert_eq!(Error::Other.code(), -9999);
+    }
+
+    #[test]
+    fn error_names_match_c_airspy_error_name() {
+        // Same strings airspy_error_name() returns in airspy.c, so tool
+        // output stays diffable against the C tools.
+        assert_eq!(Error::InvalidParam.name(), "AIRSPY_ERROR_INVALID_PARAM");
+        assert_eq!(Error::NotFound.name(), "AIRSPY_ERROR_NOT_FOUND");
+        assert_eq!(Error::Busy.name(), "AIRSPY_ERROR_BUSY");
+        assert_eq!(Error::NoMem.name(), "AIRSPY_ERROR_NO_MEM");
+        assert_eq!(Error::Unsupported.name(), "AIRSPY_ERROR_UNSUPPORTED");
+        assert_eq!(Error::Usb(rusb::Error::Io).name(), "AIRSPY_ERROR_LIBUSB");
+        assert_eq!(Error::Thread.name(), "AIRSPY_ERROR_THREAD");
+        assert_eq!(
+            Error::StreamingThread.name(),
+            "AIRSPY_ERROR_STREAMING_THREAD_ERR"
+        );
+        assert_eq!(
+            Error::StreamingStopped.name(),
+            "AIRSPY_ERROR_STREAMING_STOPPED"
+        );
+        assert_eq!(Error::Other.name(), "AIRSPY_ERROR_OTHER");
+    }
+
+    #[test]
+    fn rusb_errors_convert_into_usb_variant() {
+        let err: Error = rusb::Error::NoDevice.into();
+        assert!(matches!(err, Error::Usb(rusb::Error::NoDevice)));
+    }
+
+    #[test]
+    fn display_includes_name_and_code() {
+        // C tools print e.g. "AIRSPY_ERROR_NOT_FOUND (-5)"; Display keeps
+        // both pieces available in one string.
+        let msg = Error::NotFound.to_string();
+        assert!(msg.contains("AIRSPY_ERROR_NOT_FOUND"), "got: {msg}");
+        assert!(msg.contains("-5"), "got: {msg}");
+    }
+}

--- a/crates/libairspy/src/lib.rs
+++ b/crates/libairspy/src/lib.rs
@@ -11,3 +11,8 @@
 //!
 //! [libairspy]: https://github.com/airspy/airspyone_host
 #![warn(missing_docs)]
+
+pub mod commands;
+pub mod error;
+
+pub use error::{Error, Result};


### PR DESCRIPTION
Closes #4.

First real library code — no USB yet. TDD: the tests (written first, watched fail) pin every discriminant and name string to the C headers.

- `error.rs`: `thiserror` enum mirroring `enum airspy_error`. Success values (`AIRSPY_SUCCESS`/`AIRSPY_TRUE`) intentionally have no variant — success is `Ok`. Each variant keeps its C integer code (`code()`) and `airspy_error_name()` string (`name()`); `rusb::Error` converts via `#[from]` into the `-1000` libusb variant. Display includes both name and code so tool output stays diffable against the C tools.
- `commands.rs`: `Command` (all 28 vendor-request bytes incl. `SpiflashEraseSector = CMD_MAX = 27`), `ReceiverMode`, `SampleType` (+ `COUNT` = `AIRSPY_SAMPLE_END`), `BoardId` with `from_u8` (unknown → `None`, mirroring C's "Unknown Board ID" path) and C-exact `name()`, `GpioPort`/`GpioPin`, `ConfigPage`, `CONF_CMD_SHIFT_BIT`.
- 12 tests assert wire compatibility: every discriminant equals its C value, every name string matches the C name functions.

Verified locally: `cargo test -p libairspy-rs` (12 passed), workspace clippy `-D warnings` (all features), `cargo fmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Airspy command, receiver mode, sample type, board, GPIO, and configuration definitions.
  * Added board identification and human-readable display names.
  * Added structured error handling covering driver, USB, threading, streaming, and other failures.
  * Exposed standardized error codes, names, and result types for easier application integration.
  * Added compatibility support for Airspy’s documented USB command and error conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->