### PR TITLE
M1: vendor-request plumbing

### DIFF
--- a/crates/libairspy/src/device.rs
+++ b/crates/libairspy/src/device.rs
@@ -191,6 +191,12 @@ impl Device {
         Err(Error::NotFound)
     }
 
+    /// Borrow the underlying USB handle; the vendor-request layer in
+    /// `transfer.rs` builds on this.
+    pub(crate) fn usb_handle(&self) -> &rusb::DeviceHandle<rusb::Context> {
+        &self.handle
+    }
+
     /// Kernel-driver detach + `set_configuration(1)` +
     /// `claim_interface(0)`, exactly as `airspy_open_device` does.
     fn configure(handle: &mut rusb::DeviceHandle<rusb::Context>) -> Result<()> {

--- a/crates/libairspy/src/lib.rs
+++ b/crates/libairspy/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod commands;
 pub mod device;
 pub mod error;
+mod transfer;
 
 pub use device::{Device, list_devices};
 pub use error::{Error, Result};

--- a/crates/libairspy/src/transfer.rs
+++ b/crates/libairspy/src/transfer.rs
@@ -1,0 +1,109 @@
+//! Vendor-request plumbing — the typed control-transfer layer every
+//! device feature builds on, mirroring the `libusb_control_transfer`
+//! call pattern used throughout `airspy.c`.
+//!
+//! Each helper sends one vendor request (`commands::Command` byte as
+//! `bRequest`) with caller-supplied `wValue`/`wIndex` packing and
+//! returns the transferred byte count; call sites apply the same
+//! result checks the C library does (`!= 0` for empty writes,
+//! `< length` for data transfers).
+
+// The first consumer is the board-info layer (#8); until it lands this
+// crate-internal plumbing has no callers outside its tests.
+#![allow(dead_code)]
+
+use core::time::Duration;
+
+use crate::commands::Command;
+use crate::device::Device;
+use crate::error::Result;
+
+/// `LIBUSB_CTRL_TIMEOUT_MS` (500) in airspy.c.
+pub(crate) const CTRL_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// `LIBUSB_ENDPOINT_OUT | LIBUSB_REQUEST_TYPE_VENDOR |
+/// LIBUSB_RECIPIENT_DEVICE` — the bmRequestType of every host-to-device
+/// request in airspy.c (0x00 | 0x40 | 0x00).
+pub(crate) const VENDOR_OUT_REQUEST_TYPE: u8 = 0x40;
+
+/// `LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR |
+/// LIBUSB_RECIPIENT_DEVICE` — the bmRequestType of every device-to-host
+/// request in airspy.c (0x80 | 0x40 | 0x00).
+pub(crate) const VENDOR_IN_REQUEST_TYPE: u8 = 0xC0;
+
+impl Device {
+    /// Host-to-device vendor request. Returns the number of bytes
+    /// transferred; rusb/libusb errors map to `Error::Usb` (C's
+    /// `AIRSPY_ERROR_LIBUSB`).
+    pub(crate) fn vendor_out(
+        &self,
+        command: Command,
+        value: u16,
+        index: u16,
+        data: &[u8],
+    ) -> Result<usize> {
+        Ok(self.usb_handle().write_control(
+            VENDOR_OUT_REQUEST_TYPE,
+            command as u8,
+            value,
+            index,
+            data,
+            CTRL_TIMEOUT,
+        )?)
+    }
+
+    /// Device-to-host vendor request. Returns the number of bytes
+    /// transferred into `data`.
+    pub(crate) fn vendor_in(
+        &self,
+        command: Command,
+        value: u16,
+        index: u16,
+        data: &mut [u8],
+    ) -> Result<usize> {
+        Ok(self.usb_handle().read_control(
+            VENDOR_IN_REQUEST_TYPE,
+            command as u8,
+            value,
+            index,
+            data,
+            CTRL_TIMEOUT,
+        )?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_types_match_c_libusb_flags() {
+        // Every control transfer in airspy.c uses one of these two
+        // bmRequestType bytes; rusb::request_type is the ground truth
+        // for the same libusb flag composition.
+        assert_eq!(
+            VENDOR_OUT_REQUEST_TYPE,
+            rusb::request_type(
+                rusb::Direction::Out,
+                rusb::RequestType::Vendor,
+                rusb::Recipient::Device
+            )
+        );
+        assert_eq!(
+            VENDOR_IN_REQUEST_TYPE,
+            rusb::request_type(
+                rusb::Direction::In,
+                rusb::RequestType::Vendor,
+                rusb::Recipient::Device
+            )
+        );
+        assert_eq!(VENDOR_OUT_REQUEST_TYPE, 0x40);
+        assert_eq!(VENDOR_IN_REQUEST_TYPE, 0xC0);
+    }
+
+    #[test]
+    fn control_timeout_matches_c() {
+        // LIBUSB_CTRL_TIMEOUT_MS (500) in airspy.c.
+        assert_eq!(CTRL_TIMEOUT, core::time::Duration::from_millis(500));
+    }
+}


### PR DESCRIPTION
Closes #7. The typed control-transfer layer every device feature builds on.

- `transfer.rs`: `Device::vendor_out` / `Device::vendor_in` (crate-internal), mirroring the `libusb_control_transfer` call pattern used by all ~20 call sites in `airspy.c` — `commands::Command` byte as `bRequest`, caller-supplied `wValue`/`wIndex` packing, `LIBUSB_CTRL_TIMEOUT_MS` (500 ms) timeout, rusb errors mapping to `Error::Usb` (`AIRSPY_ERROR_LIBUSB`).
- Helpers return transferred byte counts because C's result checks vary per request (`!= 0` for empty writes, `< length` for data transfers, `< 1` for single-byte reads) — those checks stay at the call sites that own them, arriving with #8 onward.
- `bmRequestType` constants (0x40 OUT / 0xC0 IN) are pinned by tests against both the C flag composition and `rusb::request_type` as ground truth; the timeout constant is test-pinned to 500 ms.
- The layer is `pub(crate)` and carries a documented `allow(dead_code)` until its first consumer (#8, board-info reads) lands in the next PR.

TDD: constants tests written first and watched fail. 29 tests green, workspace clippy `-D warnings` all features, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for USB vendor control transfers.
  * Enabled sending commands to and receiving data from compatible devices.
  * Added consistent transfer handling with a 500 ms timeout and USB error reporting.

* **Tests**
  * Added validation for USB request types and transfer timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->