### PR TITLE
M1: airspy_info CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,58 @@ version = 4
 name = "airspy-tools"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "libairspy-rs",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
 ]
 
 [[package]]
@@ -55,6 +106,52 @@ dependencies = [
  "find-msvc-tools",
  "shlex",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "concurrent-queue"
@@ -126,6 +223,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "libairspy-rs"
 version = "0.1.0"
 dependencies = [
@@ -161,6 +270,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking"
@@ -224,6 +339,12 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -314,7 +435,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ rusb = "0.9"
 thiserror = "2"
 tracing = "0.1"
 
+# CLI (airspy-tools)
+clap = { version = "4", features = ["derive"] }
+
 # Async-runtime integrations (optional, feature-gated in libairspy-rs;
 # same pattern as librtlsdr-rs)
 futures-core = "0.3"

--- a/crates/airspy-tools/Cargo.toml
+++ b/crates/airspy-tools/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 
 [dependencies]
 libairspy-rs.workspace = true
+clap.workspace = true
 
 [lints]
 workspace = true

--- a/crates/airspy-tools/src/bin/airspy_info.rs
+++ b/crates/airspy-tools/src/bin/airspy_info.rs
@@ -1,0 +1,115 @@
+//! Port of `airspy_info.c`: enumerate Airspy boards and print their
+//! identity — board id, firmware version, part id, serial number, and
+//! supported sample rates. Output format tracks the C tool so the two
+//! can be diffed against the same hardware.
+
+use airspy_tools::parse_u64;
+use clap::Parser;
+use libairspy_rs::commands::BoardId;
+use libairspy_rs::{Device, Error, lib_version};
+
+/// `AIRSPY_MAX_DEVICE` in `airspy_info.c`.
+const MAX_DEVICES: usize = 32;
+
+#[derive(Parser)]
+#[command(
+    name = "airspy_info",
+    about = "Print information about attached Airspy boards"
+)]
+struct Args {
+    /// Open board with specified 64bits serial number
+    #[arg(short = 's', value_name = "serial_number_64bits", value_parser = parse_u64)]
+    serial_number: Option<u64>,
+}
+
+fn print_error(context: &str, err: &Error) {
+    eprintln!("{context} failed: {} ({})", err.name(), err.code());
+}
+
+fn main() {
+    let args = Args::parse();
+
+    if let Some(serial) = args.serial_number {
+        // C: "Board serial number to open: 0x%08X%08X"
+        println!(
+            "Board serial number to open: 0x{:08X}{:08X}",
+            (serial >> 32) as u32,
+            (serial & 0xFFFF_FFFF) as u32
+        );
+    }
+
+    let v = lib_version();
+    println!("airspy_lib_version: {}.{}.{}", v.major, v.minor, v.revision);
+
+    // Open every reachable board (each successful open claims its
+    // interface, so repeated opens walk the device list like C's loop).
+    let mut devices = Vec::new();
+    while devices.len() < MAX_DEVICES {
+        let result = match args.serial_number {
+            Some(serial) => Device::open_serial(serial),
+            None => Device::open(),
+        };
+        match result {
+            Ok(device) => devices.push(device),
+            Err(err) => {
+                if devices.is_empty() {
+                    print_error(&format!("airspy_open() board {}", 1), &err);
+                }
+                break;
+            }
+        }
+    }
+
+    for (i, device) in devices.iter().enumerate() {
+        let board_num = i + 1;
+        println!("\nFound AirSpy board {board_num}");
+
+        match device.board_id() {
+            Ok(board_id) => {
+                let name = BoardId::from_u8(board_id).map_or("Unknown Board ID", BoardId::name);
+                println!("Board ID Number: {board_id} ({name})");
+            }
+            Err(err) => {
+                print_error("airspy_board_id_read()", &err);
+                continue;
+            }
+        }
+
+        match device.version_string() {
+            Ok(version) => println!("Firmware Version: {version}"),
+            Err(err) => {
+                print_error("airspy_version_string_read()", &err);
+                continue;
+            }
+        }
+
+        match device.partid_serialno() {
+            Ok(ids) => {
+                println!(
+                    "Part ID Number: 0x{:08X} 0x{:08X}",
+                    ids.part_id[0], ids.part_id[1]
+                );
+                println!(
+                    "Serial Number: 0x{:08X}{:08X}",
+                    ids.serial_no[2], ids.serial_no[3]
+                );
+            }
+            Err(err) => {
+                print_error("airspy_board_partid_serialno_read()", &err);
+                continue;
+            }
+        }
+
+        println!("Supported sample rates:");
+        for rate in device.samplerates() {
+            // C: "\t%f MSPS" with a float multiply by 0.000001f.
+            #[allow(clippy::cast_precision_loss)]
+            let msps = *rate as f32 * 0.000_001;
+            println!("\t{msps:.6} MSPS");
+        }
+
+        println!("Close board {board_num}");
+    }
+    // Devices close on drop (airspy_close semantics); like the C tool,
+    // reaching this point is EXIT_SUCCESS even when no board was found.
+}

--- a/crates/airspy-tools/src/bin/airspy_info.rs
+++ b/crates/airspy-tools/src/bin/airspy_info.rs
@@ -11,6 +11,10 @@ use libairspy_rs::{Device, Error, lib_version};
 /// `AIRSPY_MAX_DEVICE` in `airspy_info.c`.
 const MAX_DEVICES: usize = 32;
 
+/// The `0.000001f` Hz→MSPS factor in `airspy_info.c`'s sample-rate
+/// printout, kept in f32 to match the C tool's float arithmetic.
+const HZ_TO_MSPS: f32 = 0.000_001;
+
 #[derive(Parser)]
 #[command(
     name = "airspy_info",
@@ -60,7 +64,9 @@ fn main() {
         }
     }
 
-    for (i, device) in devices.iter().enumerate() {
+    // Consume the vec so each Device drops (closing its handle) at the
+    // end of its iteration — C calls airspy_close inside this loop.
+    for (i, device) in devices.into_iter().enumerate() {
         let board_num = i + 1;
         println!("\nFound AirSpy board {board_num}");
 
@@ -102,9 +108,9 @@ fn main() {
 
         println!("Supported sample rates:");
         for rate in device.samplerates() {
-            // C: "\t%f MSPS" with a float multiply by 0.000001f.
+            // C: "\t%f MSPS".
             #[allow(clippy::cast_precision_loss)]
-            let msps = *rate as f32 * 0.000_001;
+            let msps = *rate as f32 * HZ_TO_MSPS;
             println!("\t{msps:.6} MSPS");
         }
 

--- a/crates/airspy-tools/src/lib.rs
+++ b/crates/airspy-tools/src/lib.rs
@@ -4,3 +4,148 @@
 //! `[[bin]]` targets while the port progresses; this library target
 //! holds the argument-parsing and output-formatting code they share.
 #![warn(missing_docs)]
+
+/// Failure to parse a `parse_u64`-style argument
+/// (C returns `AIRSPY_ERROR_INVALID_PARAM`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseU64Error;
+
+impl std::fmt::Display for ParseU64Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("AIRSPY_ERROR_INVALID_PARAM (-2)")
+    }
+}
+
+impl std::error::Error for ParseU64Error {}
+
+/// Parse a numeric CLI argument exactly as `parse_u64` in the C tools
+/// does: a `0x`/`0X` prefix on the raw string selects base 16 and
+/// `0b`/`0B` selects base 2 — but only when the string is longer than
+/// two characters — otherwise base 10. The tail then goes through
+/// `strtoull` semantics, and the whole string must be consumed
+/// (`(s != s_end) && (*s_end == 0)`).
+pub fn parse_u64(s: &str) -> Result<u64, ParseU64Error> {
+    // Prefix detection inspects raw bytes before any whitespace
+    // handling, exactly as the C code indexes s[0]/s[1]; both prefix
+    // bytes are ASCII so slicing at 2 is boundary-safe when matched.
+    let bytes = s.as_bytes();
+    let (tail, base) = if s.len() > 2 && bytes[0] == b'0' {
+        match bytes[1] {
+            b'x' | b'X' => (&s[2..], 16),
+            b'b' | b'B' => (&s[2..], 2),
+            _ => (s, 10),
+        }
+    } else {
+        (s, 10)
+    };
+    strtoull_whole(tail, base).ok_or(ParseU64Error)
+}
+
+/// `strtoull(s, &end, base)` with C's `parse_u64` acceptance check
+/// (`s != s_end && *s_end == 0`): skip `isspace()` whitespace, accept
+/// one optional sign (`-` negates with unsigned wraparound), in base
+/// 16 strip one more `0x`/`0X` when a hex digit follows, consume
+/// digits (saturating to `u64::MAX` on overflow, as strtoull clamps to
+/// `ULLONG_MAX`) — and require that digits were consumed and nothing
+/// remains.
+fn strtoull_whole(s: &str, base: u32) -> Option<u64> {
+    // C isspace(): space, \t, \n, \v, \f, \r.
+    let s = s.trim_start_matches([' ', '\t', '\n', '\x0B', '\x0C', '\r']);
+    let (negative, s) = match s.strip_prefix(['+', '-']) {
+        Some(rest) => (s.starts_with('-'), rest),
+        None => (false, s),
+    };
+    let s = if base == 16 {
+        match s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+            Some(rest) if rest.starts_with(|c: char| c.is_ascii_hexdigit()) => rest,
+            _ => s,
+        }
+    } else {
+        s
+    };
+    let mut value: u64 = 0;
+    let mut saturated = false;
+    let mut digits = 0usize;
+    let mut chars = s.chars();
+    for c in chars.by_ref() {
+        let Some(d) = c.to_digit(base) else {
+            // A non-digit before the end means the whole string was
+            // not consumed — C's *s_end != 0 reject path.
+            return None;
+        };
+        digits += 1;
+        if !saturated {
+            match value
+                .checked_mul(u64::from(base))
+                .and_then(|v| v.checked_add(u64::from(d)))
+            {
+                Some(v) => value = v,
+                None => saturated = true,
+            }
+        }
+    }
+    if digits == 0 {
+        return None;
+    }
+    // On overflow strtoull returns ULLONG_MAX without applying the
+    // sign; otherwise '-' negates with unsigned wraparound.
+    Some(if saturated {
+        u64::MAX
+    } else if negative {
+        value.wrapping_neg()
+    } else {
+        value
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_decimal_hex_and_binary_like_c_parse_u64() {
+        // parse_u64 in airspy_info.c (and the other C tools): a 0x/0X
+        // prefix selects base 16, 0b/0B selects base 2, otherwise
+        // base 10 — and the whole string must be consumed.
+        assert_eq!(parse_u64("644064DC"), Err(ParseU64Error));
+        assert_eq!(parse_u64("12345"), Ok(12345));
+        assert_eq!(parse_u64("0x644064DC"), Ok(0x6440_64DC));
+        assert_eq!(parse_u64("0X644064DC"), Ok(0x6440_64DC));
+        assert_eq!(parse_u64("0b1010"), Ok(10));
+        assert_eq!(parse_u64("0B1010"), Ok(10));
+    }
+
+    #[test]
+    fn requires_full_string_consumption() {
+        // C checks (s != s_end) && (*s_end == 0).
+        assert_eq!(parse_u64("123abc"), Err(ParseU64Error));
+        assert_eq!(parse_u64("0x12ZZ"), Err(ParseU64Error));
+        assert_eq!(parse_u64(""), Err(ParseU64Error));
+        assert_eq!(parse_u64("0x"), Err(ParseU64Error));
+    }
+
+    #[test]
+    fn inherits_strtoull_semantics_after_prefix_detection() {
+        // C's parse_u64 detects the base prefix on the raw string,
+        // then hands the tail to strtoull — which itself skips leading
+        // whitespace, accepts one sign ('-' wraps as unsigned),
+        // saturates on overflow, and in base 16 strips another 0x.
+        assert_eq!(parse_u64(" 10"), Ok(10));
+        assert_eq!(parse_u64("+10"), Ok(10));
+        assert_eq!(parse_u64("-1"), Ok(u64::MAX));
+        assert_eq!(parse_u64("99999999999999999999999"), Ok(u64::MAX));
+        assert_eq!(parse_u64("0x0x10"), Ok(0x10));
+        // Whitespace inside the prefix defeats detection: base stays
+        // 10 and strtoull stops at 'x'.
+        assert_eq!(parse_u64(" 0x10"), Err(ParseU64Error));
+    }
+
+    #[test]
+    fn short_strings_skip_prefix_detection() {
+        // C only inspects prefixes when strlen(s) > 2, so "0x" alone
+        // is a base-10 parse that fails at 'x', and "0b" likewise.
+        assert_eq!(parse_u64("0b"), Err(ParseU64Error));
+        // Two-char decimals still parse.
+        assert_eq!(parse_u64("42"), Ok(42));
+    }
+}

--- a/crates/libairspy/src/device.rs
+++ b/crates/libairspy/src/device.rs
@@ -50,7 +50,8 @@ const FALLBACK_SAMPLERATES: [u32; 2] = [10_000_000, 2_500_000];
 
 /// Cap on the firmware-reported rate count: a control transfer's
 /// wLength is a `u16`, so more than `u16::MAX / 4` words cannot
-/// arrive in one read (C truncates the length cast instead).
+/// arrive in one read (`airspy_read_samplerates_from_fw` in airspy.c
+/// passes `count * sizeof(uint32_t)` through that cast, truncating).
 const MAX_SAMPLERATE_COUNT: u32 = (u16::MAX as u32) / 4;
 
 /// Decode little-endian `u32` sample rates from the bytes actually

--- a/crates/libairspy/src/device.rs
+++ b/crates/libairspy/src/device.rs
@@ -246,6 +246,9 @@ impl Device {
             return Ok(Vec::new());
         }
         let mut raw = vec![0u8; count as usize * 4];
+        // count ≤ MAX_SAMPLERATE_COUNT < u16::MAX, so the fallback is
+        // unreachable — it exists only to keep this conversion
+        // panic-free without an unwrap.
         let index = u16::try_from(count).unwrap_or(u16::MAX);
         let n = self.vendor_in(Command::GetSamplerates, 0, index, &mut raw)?;
         if n < 1 {

--- a/crates/libairspy/src/device.rs
+++ b/crates/libairspy/src/device.rs
@@ -8,6 +8,7 @@
 
 use rusb::UsbContext as _;
 
+use crate::commands::Command;
 use crate::error::{Error, Result};
 
 /// USB vendor id (`airspy_usb_vid` in airspy.c).
@@ -41,6 +42,24 @@ const fn serial_filter(serial_number: u64) -> Option<u64> {
     } else {
         Some(serial_number)
     }
+}
+
+/// Fallback rate table from `airspy_open_init` (airspy.c), used when
+/// the firmware `AIRSPY_GET_SAMPLERATES` query fails.
+const FALLBACK_SAMPLERATES: [u32; 2] = [10_000_000, 2_500_000];
+
+/// Cap on the firmware-reported rate count: a control transfer's
+/// wLength is a `u16`, so more than `u16::MAX / 4` words cannot
+/// arrive in one read (C truncates the length cast instead).
+const MAX_SAMPLERATE_COUNT: u32 = (u16::MAX as u32) / 4;
+
+/// Decode little-endian `u32` sample rates from the bytes actually
+/// transferred, dropping any partial trailing word (C leaves the tail
+/// of its buffer uninitialized on a short read; we simply omit it).
+fn samplerates_from_le_bytes(raw: &[u8]) -> Vec<u32> {
+    raw.chunks_exact(4)
+        .filter_map(|chunk| chunk.try_into().ok().map(u32::from_le_bytes))
+        .collect()
 }
 
 /// Parse an Airspy serial-number string descriptor into its `u64`
@@ -151,6 +170,7 @@ pub fn list_devices() -> Result<Vec<u64>> {
 #[derive(Debug)]
 pub struct Device {
     handle: rusb::DeviceHandle<rusb::Context>,
+    supported_samplerates: Vec<u32>,
 }
 
 impl Device {
@@ -186,9 +206,52 @@ impl Device {
                 // configuration/claim failure.
                 continue;
             }
-            return Ok(Self { handle });
+            let mut device = Self {
+                handle,
+                supported_samplerates: Vec::new(),
+            };
+            // airspy_open_init caches the firmware rate table at open,
+            // falling back to a fixed pair when the query fails.
+            device.supported_samplerates = device
+                .read_samplerates_from_fw()
+                .unwrap_or_else(|_| FALLBACK_SAMPLERATES.to_vec());
+            return Ok(device);
         }
         Err(Error::NotFound)
+    }
+
+    /// The supported sample rates cached at open
+    /// (`airspy_get_samplerates`; the C length/count two-call protocol
+    /// collapses into a slice).
+    ///
+    /// C doubles these values when a real (non-IQ) sample type is
+    /// selected; sample-type selection arrives with the streaming
+    /// engine, which revisits this.
+    #[must_use]
+    pub fn samplerates(&self) -> &[u32] {
+        &self.supported_samplerates
+    }
+
+    /// `airspy_read_samplerates_from_fw`: a 4-byte count query
+    /// (wIndex = 0) followed by a count-word read (wIndex = count).
+    fn read_samplerates_from_fw(&self) -> Result<Vec<u32>> {
+        let mut count_raw = [0u8; 4];
+        let n = self.vendor_in(Command::GetSamplerates, 0, 0, &mut count_raw)?;
+        if n < 1 {
+            // C: result < 1 → AIRSPY_ERROR_OTHER.
+            return Err(Error::Other);
+        }
+        let count = u32::from_le_bytes(count_raw).min(MAX_SAMPLERATE_COUNT);
+        if count == 0 {
+            return Ok(Vec::new());
+        }
+        let mut raw = vec![0u8; count as usize * 4];
+        let index = u16::try_from(count).unwrap_or(u16::MAX);
+        let n = self.vendor_in(Command::GetSamplerates, 0, index, &mut raw)?;
+        if n < 1 {
+            return Err(Error::Other);
+        }
+        Ok(samplerates_from_le_bytes(&raw[..n]))
     }
 
     /// Borrow the underlying USB handle; the vendor-request layer in
@@ -397,5 +460,35 @@ mod tests {
             Device::open_serial(unknown_serial),
             Err(crate::Error::NotFound)
         ));
+    }
+}
+
+#[cfg(test)]
+mod samplerate_tests {
+    use super::*;
+
+    #[test]
+    fn fallback_table_matches_c() {
+        // airspy_open_init's fallback when the firmware rate query
+        // fails: {10000000, 2500000}.
+        assert_eq!(FALLBACK_SAMPLERATES, [10_000_000, 2_500_000]);
+    }
+
+    #[test]
+    fn samplerate_words_parse_little_endian() {
+        let mut raw = Vec::new();
+        raw.extend_from_slice(&10_000_000u32.to_le_bytes());
+        raw.extend_from_slice(&2_500_000u32.to_le_bytes());
+        assert_eq!(samplerates_from_le_bytes(&raw), vec![10_000_000, 2_500_000]);
+    }
+
+    #[test]
+    fn partial_trailing_word_is_dropped() {
+        // Only complete words actually transferred are surfaced; C
+        // would leave the tail of its malloc'd buffer uninitialized.
+        let mut raw = Vec::new();
+        raw.extend_from_slice(&6_000_000u32.to_le_bytes());
+        raw.extend_from_slice(&[0x01, 0x02]);
+        assert_eq!(samplerates_from_le_bytes(&raw), vec![6_000_000]);
     }
 }

--- a/crates/libairspy/src/lib.rs
+++ b/crates/libairspy/src/lib.rs
@@ -21,3 +21,41 @@ mod transfer;
 pub use board::PartIdSerial;
 pub use device::{Device, list_devices};
 pub use error::{Error, Result};
+
+/// Library version, mirroring `airspy_lib_version` /
+/// `airspy_lib_version_t` — reporting this crate's own version rather
+/// than the C library's 1.0.12.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LibVersion {
+    /// `major_version`
+    pub major: u32,
+    /// `minor_version`
+    pub minor: u32,
+    /// `revision`
+    pub revision: u32,
+}
+
+/// The version of this crate (`airspy_lib_version` semantics).
+#[must_use]
+pub fn lib_version() -> LibVersion {
+    let parse = |s: &str| s.parse().unwrap_or(0);
+    LibVersion {
+        major: parse(env!("CARGO_PKG_VERSION_MAJOR")),
+        minor: parse(env!("CARGO_PKG_VERSION_MINOR")),
+        revision: parse(env!("CARGO_PKG_VERSION_PATCH")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lib_version_matches_crate_version() {
+        let v = lib_version();
+        assert_eq!(
+            format!("{}.{}.{}", v.major, v.minor, v.revision),
+            env!("CARGO_PKG_VERSION")
+        );
+    }
+}


### PR DESCRIPTION
Closes #9 — completes the M1 milestone's tool: the end-to-end hardware smoke test for when the R2 arrives.

- **`airspy_info` binary** (first `airspy-tools` bin, clap-based): mirrors the C tool's output line-for-line — `Board serial number to open`, `airspy_lib_version`, per-board `Found AirSpy board N` / board id + name (incl. "Unknown Board ID") / firmware version / part id / serial (words 2+3) / sample-rate list (`\t%f MSPS`, f32 multiply like C) / `Close board N`. Exit code semantics match C (success even with no boards; errors to stderr with `AIRSPY_ERROR_*` name + code). Deviation: getopt → clap, so usage/parse-error formatting is clap's (per issue scope).
- **Samplerate support pulled forward from #20** (the tool needs it; the *setter* stays in #20): `Device` now caches the firmware rate table at open via the two-call `AIRSPY_GET_SAMPLERATES` protocol with C's `{10 MSPS, 2.5 MSPS}` fallback, exposed as `samplerates()`. Count capped at what a control transfer's u16 wLength can carry (C truncates the cast); only fully-transferred words surfaced (C leaves its buffer tail uninitialized). The non-IQ ×2 doubling is documented for the M2 sample-type work.
- **`lib_version()`** mirroring `airspy_lib_version`, reporting this crate's version.
- **Shared `parse_u64`** in the tools lib with the C tools' exact semantics: raw-string prefix detection (`0x`/`0X`/`0b`/`0B`, only when len > 2) then full `strtoull` behavior — whitespace, sign with unsigned wraparound, overflow saturation to `ULLONG_MAX` (unsigned), base-16 re-prefixing — and whole-string consumption. All pinned by tests, informed by the strtoull findings on #44.

TDD throughout (parse_u64 semantics, samplerate LE parsing + fallback table, lib_version). 43 tests green, workspace clippy `-D warnings` all features, fmt clean. Smoke-run without hardware: serial banner, version line, and `AIRSPY_ERROR_NOT_FOUND (-5)` path all match the C shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `airspy_info` command to display connected device details, firmware versions, serial numbers, part IDs, and supported sample rates.
  * Added library version access through major, minor, and patch components.
  * Added device sample-rate discovery with fallback rates when unavailable.
  * Added flexible serial-number input supporting decimal, hexadecimal, and binary formats.
* **Bug Fixes**
  * Improved handling and reporting of device-operation and data-parsing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->