### PR TITLE
CI: coverage reporting (cargo-llvm-cov → Codacy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,3 +187,74 @@ jobs:
 
   # `cargo-deny` runs in its own dedicated workflow (`.github/workflows/deny.yml`)
   # which adds a weekly cron on top of per-PR runs.
+
+  # Workspace coverage → Codacy, following the rtl-sdr pipeline: this
+  # job executes workspace code (build scripts, tests) and therefore
+  # never sees the Codacy token — the report travels to a separate
+  # upload job as an artifact, so a compromised build script cannot
+  # reach the token (e.g. by appending `BASH_ENV=` to `$GITHUB_ENV`).
+  codacy-coverage:
+    name: Coverage report (Codacy)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Untrusted PR code runs in this job; it needs no git credentials.
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          key: coverage
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libusb-1.0-0-dev pkg-config
+      - name: Install cargo-llvm-cov
+        run: cargo install --locked cargo-llvm-cov
+      - name: Workspace coverage (LCOV)
+        run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: lcov
+          path: lcov.info
+          retention-days: 7
+
+  # Upload-only job: no checkout, no workspace code — just the LCOV
+  # artifact and a pinned, checksum-verified reporter binary. Skips
+  # the upload when `CODACY_PROJECT_TOKEN` is not configured (forks,
+  # or before the secret exists) instead of failing the workflow.
+  codacy-upload:
+    name: Coverage upload (Codacy)
+    needs: codacy-coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      # Only a presence flag at job scope (a step's own `env` is not
+      # visible to its own `if`); the token itself is scoped to the
+      # upload step.
+      HAS_CODACY_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: lcov
+      # The official action is SHA-pinned only for its action.yml; it
+      # then bootstraps `get.sh` from the reporter repo's mutable
+      # `master` branch and hands the token to whatever that fetched.
+      # Fetch a pinned release of the reporter instead and verify it
+      # against a checksum recorded here before the token is exposed.
+      - name: Upload to Codacy
+        if: ${{ env.HAS_CODACY_TOKEN == 'true' }}
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          REPORTER_VERSION: 14.1.3
+          REPORTER_SHA512: 73a6c93fc5db509fd0423d6e545759c3f61d8360ee12054e32a9277daab6add0da6c6639248f6ed6c0042366440293ebc0b6144325aef52c5d3d4b230d65eb17
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 3 -o codacy-coverage-reporter \
+            "https://github.com/codacy/codacy-coverage-reporter/releases/download/${REPORTER_VERSION}/codacy-coverage-reporter-linux"
+          echo "${REPORTER_SHA512}  codacy-coverage-reporter" | sha512sum -c -
+          chmod +x codacy-coverage-reporter
+          ./codacy-coverage-reporter report -r lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Install cargo-llvm-cov
         run: cargo install --locked cargo-llvm-cov
       - name: Workspace coverage (LCOV)
-        run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+        run: cargo llvm-cov --locked --workspace --all-features --lcov --output-path lcov.info
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libusb-1.0-0-dev pkg-config
       - name: Install cargo-llvm-cov
-        run: cargo install --locked cargo-llvm-cov
+        run: cargo install --locked cargo-llvm-cov --version 0.8.5
       - name: Workspace coverage (LCOV)
         run: cargo llvm-cov --locked --workspace --all-features --lcov --output-path lcov.info
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
Closes #49 — the rtl-sdr coverage pipeline, ported verbatim in structure:

- **Coverage report (Codacy)**: `cargo llvm-cov --workspace --all-features --lcov` on stable + llvm-tools-preview; the LCOV travels as a build artifact. This job runs workspace code (build scripts, tests) and therefore never sees the Codacy token.
- **Coverage upload (Codacy)**: no checkout, artifact-only. Downloads a pinned `codacy-coverage-reporter` 14.1.3 release binary and verifies it against a recorded SHA512 *before* the token is exposed (the official action bootstraps a mutable `get.sh` — same reason rtl-sdr avoids it). Skips gracefully while `CODACY_PROJECT_TOKEN` isn't configured.
- Neither job is a required status check; no gate initially — dashboard feed first, thresholds once the DSP milestone lands.

**Action needed from @jasonherald**: add the `CODACY_PROJECT_TOKEN` repo secret (Codacy → repository settings → coverage) whenever convenient; until then the upload step no-ops.

Verified: `actionlint` clean; local `cargo llvm-cov --workspace --all-features` runs green (67% lines — uncovered code is the hardware-only USB paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved automated code coverage reporting for more reliable quality tracking.
  - Coverage reports are now securely validated before being submitted.
  - Reporting runs conditionally when the required configuration is available, helping keep builds resilient.
  - Coverage results are preserved temporarily as downloadable build artifacts, making them easier to review and troubleshoot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->