### PR TITLE
M2: sample-type plumbing + typed callback API

### DIFF
--- a/crates/airspy-tools/src/bin/airspy_info.rs
+++ b/crates/airspy-tools/src/bin/airspy_info.rs
@@ -110,7 +110,7 @@ fn main() {
         for rate in device.samplerates() {
             // C: "\t%f MSPS".
             #[allow(clippy::cast_precision_loss)]
-            let msps = *rate as f32 * HZ_TO_MSPS;
+            let msps = rate as f32 * HZ_TO_MSPS;
             println!("\t{msps:.6} MSPS");
         }
 

--- a/crates/libairspy/src/conversion.rs
+++ b/crates/libairspy/src/conversion.rs
@@ -16,11 +16,12 @@ const SAMPLES_PER_GROUP: usize = 8;
 /// little-endian host; loading through `u32::from_le_bytes` gives the
 /// identical values portably and without alignment requirements.
 ///
-/// Returns the number of samples written. Deviation from C: only
-/// complete 12-byte/8-sample groups are processed. C's loop runs to a
-/// `sample_count` that is not a multiple of 8 (262144-byte buffers
-/// give 174762) and overruns both buffers on the final partial group
-/// — an upstream out-of-bounds this port does not reproduce.
+/// Returns the number of samples written — `input_bytes * 2 / 3`,
+/// matching C's packed `sample_count` (174762 for a 262144-byte
+/// buffer). The final partial group's samples are decoded from its
+/// in-bounds words only; C instead runs its full 8-sample loop body
+/// there, reading past the input and writing past the output (an
+/// upstream out-of-bounds this port does not reproduce).
 // Every assembled value is at most 12 bits ((0xFF << 4) | 0xF =
 // 0xFFF), but clippy cannot prove it through the shift-or pairs.
 #[allow(clippy::cast_possible_truncation)]
@@ -53,7 +54,37 @@ pub(crate) fn unpack_samples(input: &[u8], output: &mut [u16]) -> usize {
         samples[6] = ((w2 >> 12) & 0xFFF) as u16;
         samples[7] = (w2 & 0xFFF) as u16;
     }
-    groups * SAMPLES_PER_GROUP
+
+    // Partial tail: decode the samples fully contained in the
+    // remaining in-bounds words (a 4-byte tail carries s0/s1, an
+    // 8-byte tail s0..s4 of the C layout above). This is how the port
+    // reaches C's bytes*2/3 count without C's overrun.
+    let mut written = groups * SAMPLES_PER_GROUP;
+    let tail = &input[groups * BYTES_PER_GROUP..];
+    if tail.len() >= 4 {
+        let w0 = word(tail, 0);
+        let mut push = |v: u32| {
+            if let Some(slot) = output.get_mut(written) {
+                *slot = v as u16;
+                written += 1;
+            }
+        };
+        push((w0 >> 20) & 0xFFF);
+        push((w0 >> 8) & 0xFFF);
+        if tail.len() >= 8 {
+            let w1 = word(tail, 1);
+            push(((w0 & 0xFF) << 4) | ((w1 >> 28) & 0xF));
+            push((w1 & 0x0FFF_0000) >> 16);
+            push((w1 & 0xFFF0) >> 4);
+        }
+    }
+    written
+}
+
+/// The sample count [`unpack_samples`] yields for `len` packed bytes —
+/// C's `((buffer_size / 2) * 4) / 3` generalized: `len * 2 / 3`.
+pub(crate) const fn unpacked_sample_count(len: usize) -> usize {
+    len * 2 / 3
 }
 
 use crate::commands::SampleType;
@@ -110,6 +141,37 @@ pub(crate) struct Scratch {
     out_f32: Vec<f32>,
 }
 
+impl Scratch {
+    /// Preallocate for a stream delivering `buffer_len`-byte blocks in
+    /// the latched format, so the consumer loop never grows a vector
+    /// on the hot path (C allocates its counterparts at open).
+    pub(crate) fn for_stream(
+        sample_type: SampleType,
+        packing_enabled: bool,
+        buffer_len: usize,
+    ) -> Self {
+        let word_count = if packing_enabled {
+            unpacked_sample_count(buffer_len)
+        } else {
+            buffer_len / 2
+        };
+        let mut scratch = Self::default();
+        if packing_enabled {
+            scratch.unpacked.reserve(word_count);
+        } else {
+            scratch.words.reserve(word_count);
+        }
+        match sample_type {
+            SampleType::Int16Real | SampleType::Int16Iq => scratch.out_i16.reserve(word_count),
+            SampleType::Float32Real | SampleType::Float32Iq => {
+                scratch.out_f32.reserve(word_count);
+            }
+            SampleType::Uint16Real | SampleType::Raw => {}
+        }
+        scratch
+    }
+}
+
 /// The sample-type dispatch from `consumer_threadproc` (airspy.c):
 /// optional 12-bit unpack, then per-type conversion. Returns the
 /// typed samples plus the sample count C would report for the block.
@@ -122,10 +184,19 @@ pub(crate) fn convert_block<'a>(
     bytes: &'a [u8],
     scratch: &'a mut Scratch,
 ) -> (Samples<'a>, usize) {
+    // RAW (and the not-yet-supported IQ types, which start_rx refuses
+    // and which degrade to RAW delivery here) bypass all preparation.
+    if matches!(
+        sample_type,
+        SampleType::Raw | SampleType::Float32Iq | SampleType::Int16Iq
+    ) {
+        return (Samples::Raw(bytes), bytes.len() / 2);
+    }
     // C: packing_enabled && sample_type != RAW → unpack first.
-    let words: &[u16] = if packing_enabled && sample_type != SampleType::Raw {
-        let max = bytes.len() / BYTES_PER_GROUP * SAMPLES_PER_GROUP;
-        scratch.unpacked.resize(max, 0);
+    let words: &[u16] = if packing_enabled {
+        scratch
+            .unpacked
+            .resize(unpacked_sample_count(bytes.len()), 0);
         let n = unpack_samples(bytes, &mut scratch.unpacked);
         &scratch.unpacked[..n]
     } else {
@@ -140,11 +211,8 @@ pub(crate) fn convert_block<'a>(
         &scratch.words
     };
     match sample_type {
-        // IQ conversion arrives with the DSP milestone; start_rx
-        // refuses these types until then, so this arm is unreachable
-        // in practice and degrades to RAW delivery.
         SampleType::Raw | SampleType::Float32Iq | SampleType::Int16Iq => {
-            (Samples::Raw(bytes), bytes.len() / 2)
+            unreachable!("handled by the early return above")
         }
         SampleType::Uint16Real => (Samples::Uint16(words), words.len()),
         SampleType::Int16Real => {
@@ -163,6 +231,7 @@ pub(crate) fn convert_block<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::SampleType;
 
     /// Test-only inverse of the unpacker: pack eight 12-bit samples
     /// into three words exactly as the firmware lays them out
@@ -222,23 +291,40 @@ mod tests {
     }
 
     #[test]
-    fn clamps_to_complete_groups() {
-        // C's loop overruns on a partial tail (sample_count 174762 is
-        // not a multiple of 8 — an upstream OOB); the port processes
-        // complete 3-word/8-sample groups only and reports what it
-        // wrote.
+    fn decodes_partial_tail_without_overrun() {
+        // C's packed count is bytes*2/3 (174762 for a 262144-byte
+        // buffer): the final partial group's in-bounds words carry
+        // real samples. A 4-byte tail yields s0/s1 of that group; an
+        // 8-byte tail yields s0..s4; C's OOB reads for the rest are
+        // not reproduced.
         let mut input = pack_group([9, 8, 7, 6, 5, 4, 3, 2]);
-        // Eight extra bytes: not enough for another 12-byte group.
-        input.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF, 0x12, 0x34, 0x56, 0x78]);
+        // 4-byte tail: w0 = 0x12345678 → s0=0x123, s1=0x456.
+        input.extend_from_slice(&[0x78, 0x56, 0x34, 0x12]);
         let mut output = [0u16; 16];
-        assert_eq!(unpack_samples(&input, &mut output), 8);
+        assert_eq!(unpack_samples(&input, &mut output), 10);
         assert_eq!(&output[..8], &[9, 8, 7, 6, 5, 4, 3, 2]);
-        // Untouched tail.
-        assert_eq!(&output[8..], &[0u16; 8]);
+        assert_eq!(&output[8..10], &[0x123, 0x456]);
 
-        // Output shorter than the input allows: clamp to output groups.
-        let mut short_out = [0u16; 11]; // one full group only
-        assert_eq!(unpack_samples(&input, &mut short_out), 8);
+        // 8-byte tail: w0=0x12345678, w1=0x9ABCDEF0 → s0..s4.
+        let mut input8 = pack_group([9, 8, 7, 6, 5, 4, 3, 2]);
+        input8.extend_from_slice(&[0x78, 0x56, 0x34, 0x12, 0xF0, 0xDE, 0xBC, 0x9A]);
+        let mut output = [0u16; 16];
+        assert_eq!(unpack_samples(&input8, &mut output), 13);
+        assert_eq!(&output[8..13], &[0x123, 0x456, 0x789, 0xABC, 0xDEF]);
+
+        // Output shorter than available samples: tail fills what fits.
+        let mut short_out = [0u16; 11];
+        assert_eq!(unpack_samples(&input8, &mut short_out), 11);
+        assert_eq!(&short_out[8..], &[0x123, 0x456, 0x789]);
+    }
+
+    #[test]
+    fn full_stream_buffer_matches_c_sample_count() {
+        // 262144-byte packed buffer → C's ((buffer_size/2)*4)/3 =
+        // 174762 samples, now reached without C's overrun.
+        let input = vec![0u8; 262_144];
+        let mut output = vec![0u16; 175_000];
+        assert_eq!(unpack_samples(&input, &mut output), 174_762);
     }
 
     #[test]
@@ -261,12 +347,6 @@ mod tests {
         unpack_samples(&[0u8; 12], &mut output);
         assert_eq!(output, [0u16; 8]);
     }
-}
-
-#[cfg(test)]
-mod convert_tests {
-    use super::*;
-    use crate::commands::SampleType;
 
     #[test]
     fn scale_and_shift_match_c() {
@@ -343,15 +423,7 @@ mod convert_tests {
     fn dispatch_unpacks_before_converting_when_packing_enabled() {
         // consumer_threadproc: packing_enabled && type != RAW → unpack
         // first. One packed group of 2048s converts to eight zeros.
-        let packed: Vec<u8> = {
-            let s: Vec<u32> = std::iter::repeat_n(2048u32, 8).collect();
-            let words = [
-                (s[0] << 20) | (s[1] << 8) | (s[2] >> 4),
-                ((s[2] & 0xF) << 28) | (s[3] << 16) | (s[4] << 4) | (s[5] >> 8),
-                ((s[5] & 0xFF) << 24) | (s[6] << 12) | s[7],
-            ];
-            words.iter().flat_map(|w| w.to_le_bytes()).collect()
-        };
+        let packed = pack_group([2048u16; 8]);
         let mut scratch = Scratch::default();
         let (samples, count) = convert_block(SampleType::Int16Real, true, &packed, &mut scratch);
         assert_eq!(count, 8);

--- a/crates/libairspy/src/conversion.rs
+++ b/crates/libairspy/src/conversion.rs
@@ -21,9 +21,6 @@ const SAMPLES_PER_GROUP: usize = 8;
 /// `sample_count` that is not a multiple of 8 (262144-byte buffers
 /// give 174762) and overruns both buffers on the final partial group
 /// — an upstream out-of-bounds this port does not reproduce.
-// Consumed by the sample-type pipeline (#12); until that lands the
-// unpacker has no callers outside its tests.
-#[allow(dead_code)]
 // Every assembled value is at most 12 bits ((0xFF << 4) | 0xF =
 // 0xFFF), but clippy cannot prove it through the shift-or pairs.
 #[allow(clippy::cast_possible_truncation)]
@@ -57,6 +54,110 @@ pub(crate) fn unpack_samples(input: &[u8], output: &mut [u16]) -> usize {
         samples[7] = (w2 & 0xFFF) as u16;
     }
     groups * SAMPLES_PER_GROUP
+}
+
+use crate::commands::SampleType;
+
+/// `SAMPLE_SHIFT` (airspy.c): `SAMPLE_ENCAPSULATION (16) -
+/// SAMPLE_RESOLUTION (12)`.
+const SAMPLE_SHIFT: i32 = 4;
+
+/// `SAMPLE_SCALE` (airspy.c): `1.0f / (1 << (15 - SAMPLE_SHIFT))`.
+const SAMPLE_SCALE: f32 = 1.0 / 2048.0;
+
+/// `convert_samples_int16` (airspy.c): `(src - 2048) << SAMPLE_SHIFT`,
+/// computed in `int` and stored as `int16_t`.
+// Truncation is the C cast: the shifted value spans -32768..32752.
+#[allow(clippy::cast_possible_truncation)]
+fn convert_samples_int16(src: &[u16], dest: &mut [i16]) {
+    for (s, d) in src.iter().zip(dest.iter_mut()) {
+        *d = ((i32::from(*s) - 2048) << SAMPLE_SHIFT) as i16;
+    }
+}
+
+/// `convert_samples_float` (airspy.c): `(src - 2048) * SAMPLE_SCALE`.
+#[allow(clippy::cast_precision_loss)]
+fn convert_samples_float(src: &[u16], dest: &mut [f32]) {
+    for (s, d) in src.iter().zip(dest.iter_mut()) {
+        *d = (i32::from(*s) - 2048) as f32 * SAMPLE_SCALE;
+    }
+}
+
+/// One block of delivered samples in the format selected via
+/// [`SampleType`] — the typed face of C's `airspy_transfer.samples`
+/// `void*`.
+#[derive(Debug)]
+pub enum Samples<'a> {
+    /// `AIRSPY_SAMPLE_FLOAT32_REAL` (and, with the DSP milestone,
+    /// `FLOAT32_IQ`).
+    Float32(&'a [f32]),
+    /// `AIRSPY_SAMPLE_INT16_REAL` (and, with the DSP milestone,
+    /// `INT16_IQ`).
+    Int16(&'a [i16]),
+    /// `AIRSPY_SAMPLE_UINT16_REAL` — raw ADC words.
+    Uint16(&'a [u16]),
+    /// `AIRSPY_SAMPLE_RAW` — the untouched bulk bytes.
+    Raw(&'a [u8]),
+}
+
+/// Reusable consumer-thread buffers — C's `unpacked_samples` and
+/// `output_buffer`, allocated once and recycled per block.
+#[derive(Debug, Default)]
+pub(crate) struct Scratch {
+    unpacked: Vec<u16>,
+    words: Vec<u16>,
+    out_i16: Vec<i16>,
+    out_f32: Vec<f32>,
+}
+
+/// The sample-type dispatch from `consumer_threadproc` (airspy.c):
+/// optional 12-bit unpack, then per-type conversion. Returns the
+/// typed samples plus the sample count C would report for the block.
+///
+/// The IQ types are absent until the DSP converters land (the
+/// streaming engine rejects them at `start_rx`).
+pub(crate) fn convert_block<'a>(
+    sample_type: SampleType,
+    packing_enabled: bool,
+    bytes: &'a [u8],
+    scratch: &'a mut Scratch,
+) -> (Samples<'a>, usize) {
+    // C: packing_enabled && sample_type != RAW → unpack first.
+    let words: &[u16] = if packing_enabled && sample_type != SampleType::Raw {
+        let max = bytes.len() / BYTES_PER_GROUP * SAMPLES_PER_GROUP;
+        scratch.unpacked.resize(max, 0);
+        let n = unpack_samples(bytes, &mut scratch.unpacked);
+        &scratch.unpacked[..n]
+    } else {
+        // Unpacked mode: the byte stream is little-endian u16 words
+        // (C casts the buffer; we copy into the reusable scratch).
+        scratch.words.clear();
+        scratch.words.extend(
+            bytes
+                .chunks_exact(2)
+                .map(|b| u16::from_le_bytes([b[0], b[1]])),
+        );
+        &scratch.words
+    };
+    match sample_type {
+        // IQ conversion arrives with the DSP milestone; start_rx
+        // refuses these types until then, so this arm is unreachable
+        // in practice and degrades to RAW delivery.
+        SampleType::Raw | SampleType::Float32Iq | SampleType::Int16Iq => {
+            (Samples::Raw(bytes), bytes.len() / 2)
+        }
+        SampleType::Uint16Real => (Samples::Uint16(words), words.len()),
+        SampleType::Int16Real => {
+            scratch.out_i16.resize(words.len(), 0);
+            convert_samples_int16(words, &mut scratch.out_i16);
+            (Samples::Int16(&scratch.out_i16), words.len())
+        }
+        SampleType::Float32Real => {
+            scratch.out_f32.resize(words.len(), 0.0);
+            convert_samples_float(words, &mut scratch.out_f32);
+            (Samples::Float32(&scratch.out_f32), words.len())
+        }
+    }
 }
 
 #[cfg(test)]
@@ -159,5 +260,105 @@ mod tests {
         let mut output = [0xBEEF_u16; 8];
         unpack_samples(&[0u8; 12], &mut output);
         assert_eq!(output, [0u16; 8]);
+    }
+}
+
+#[cfg(test)]
+mod convert_tests {
+    use super::*;
+    use crate::commands::SampleType;
+
+    #[test]
+    fn scale_and_shift_match_c() {
+        // SAMPLE_SHIFT = 16 - 12 = 4; SAMPLE_SCALE = 1/(1 << 11).
+        assert_eq!(SAMPLE_SHIFT, 4);
+        assert!((SAMPLE_SCALE - 1.0 / 2048.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn int16_conversion_matches_c_arithmetic() {
+        // C: dest = (src - 2048) << 4, computed in int then stored i16.
+        let src = [0u16, 2048, 4095, 2049];
+        let mut dest = [0i16; 4];
+        convert_samples_int16(&src, &mut dest);
+        assert_eq!(dest, [-32768, 0, 32752, 16]);
+    }
+
+    #[test]
+    fn float_conversion_matches_c_arithmetic() {
+        // C: dest = (src - 2048) * (1/2048.0f).
+        let src = [0u16, 2048, 4095];
+        let mut dest = [0f32; 3];
+        convert_samples_float(&src, &mut dest);
+        assert!((dest[0] + 1.0).abs() < f32::EPSILON);
+        assert!(dest[1].abs() < f32::EPSILON);
+        assert!((dest[2] - 2047.0 / 2048.0).abs() < f32::EPSILON);
+    }
+
+    fn le_bytes(words: &[u16]) -> Vec<u8> {
+        words.iter().flat_map(|w| w.to_le_bytes()).collect()
+    }
+
+    #[test]
+    fn dispatch_raw_passes_bytes_through() {
+        let bytes = [1u8, 2, 3, 4];
+        let mut scratch = Scratch::default();
+        let (samples, count) = convert_block(SampleType::Raw, false, &bytes, &mut scratch);
+        assert!(matches!(samples, Samples::Raw(b) if b == bytes));
+        assert_eq!(count, 2); // buffer_size / 2 semantics: u16 count
+    }
+
+    #[test]
+    fn dispatch_uint16_real_yields_u16_words() {
+        let bytes = le_bytes(&[100, 4095, 0, 2048]);
+        let mut scratch = Scratch::default();
+        let (samples, count) = convert_block(SampleType::Uint16Real, false, &bytes, &mut scratch);
+        assert_eq!(count, 4);
+        assert!(matches!(samples, Samples::Uint16(w) if w == [100, 4095, 0, 2048]));
+    }
+
+    #[test]
+    fn dispatch_int16_real_converts() {
+        let bytes = le_bytes(&[0, 2048, 4095, 2049]);
+        let mut scratch = Scratch::default();
+        let (samples, count) = convert_block(SampleType::Int16Real, false, &bytes, &mut scratch);
+        assert_eq!(count, 4);
+        assert!(matches!(samples, Samples::Int16(w) if w == [-32768, 0, 32752, 16]));
+    }
+
+    #[test]
+    fn dispatch_float32_real_converts() {
+        let bytes = le_bytes(&[2048, 0]);
+        let mut scratch = Scratch::default();
+        let (samples, count) = convert_block(SampleType::Float32Real, false, &bytes, &mut scratch);
+        assert_eq!(count, 2);
+        let Samples::Float32(w) = samples else {
+            unreachable!("expected float samples");
+        };
+        assert!(w[0].abs() < f32::EPSILON);
+        assert!((w[1] + 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn dispatch_unpacks_before_converting_when_packing_enabled() {
+        // consumer_threadproc: packing_enabled && type != RAW → unpack
+        // first. One packed group of 2048s converts to eight zeros.
+        let packed: Vec<u8> = {
+            let s: Vec<u32> = std::iter::repeat_n(2048u32, 8).collect();
+            let words = [
+                (s[0] << 20) | (s[1] << 8) | (s[2] >> 4),
+                ((s[2] & 0xF) << 28) | (s[3] << 16) | (s[4] << 4) | (s[5] >> 8),
+                ((s[5] & 0xFF) << 24) | (s[6] << 12) | s[7],
+            ];
+            words.iter().flat_map(|w| w.to_le_bytes()).collect()
+        };
+        let mut scratch = Scratch::default();
+        let (samples, count) = convert_block(SampleType::Int16Real, true, &packed, &mut scratch);
+        assert_eq!(count, 8);
+        assert!(matches!(samples, Samples::Int16(w) if w == [0i16; 8]));
+
+        // RAW skips the unpack even in packed mode.
+        let (samples, _) = convert_block(SampleType::Raw, true, &packed, &mut scratch);
+        assert!(matches!(samples, Samples::Raw(b) if b == packed.as_slice()));
     }
 }

--- a/crates/libairspy/src/conversion.rs
+++ b/crates/libairspy/src/conversion.rs
@@ -81,6 +81,14 @@ pub(crate) fn unpack_samples(input: &[u8], output: &mut [u16]) -> usize {
             push(((w0 & 0xFF) << 4) | ((w1 >> 28) & 0xF));
             push((w1 & 0x0FFF_0000) >> 16);
             push((w1 & 0xFFF0) >> 4);
+            if tail.len() >= BYTES_PER_GROUP {
+                // A full group landed in the tail because the output
+                // bound (not the input) limited the group loop.
+                let w2 = word(tail, 2);
+                push(((w1 & 0xF) << 8) | ((w2 & 0xFF00_0000) >> 24));
+                push((w2 >> 12) & 0xFFF);
+                push(w2 & 0xFFF);
+            }
         }
     }
     written
@@ -329,6 +337,27 @@ mod tests {
         let mut short_out = [0u16; 11];
         assert_eq!(unpack_samples(&input8, &mut short_out), 11);
         assert_eq!(&short_out[8..], &[0x123, 0x456, 0x789]);
+    }
+
+    #[test]
+    fn output_bounded_decoding_fills_every_slot() {
+        // With ample input, an output of 7 gets 7 samples (s0..s6 of
+        // the first group), and an output of 15 gets a full group plus
+        // s0..s6 of the next — the output bound, not the group shape,
+        // limits what is written.
+        let g1 = [0x111, 0x222, 0x333, 0x444, 0x555, 0x666, 0x777, 0x888];
+        let g2 = [0x999, 0xAAA, 0xBBB, 0xCCC, 0xDDD, 0xEEE, 0xFFF, 0x123];
+        let mut input = pack_group(g1);
+        input.extend_from_slice(&pack_group(g2));
+
+        let mut out7 = [0u16; 7];
+        assert_eq!(unpack_samples(&input, &mut out7), 7);
+        assert_eq!(out7, g1[..7]);
+
+        let mut out15 = [0u16; 15];
+        assert_eq!(unpack_samples(&input, &mut out15), 15);
+        assert_eq!(&out15[..8], &g1);
+        assert_eq!(&out15[8..], &g2[..7]);
     }
 
     #[test]

--- a/crates/libairspy/src/conversion.rs
+++ b/crates/libairspy/src/conversion.rs
@@ -2,9 +2,12 @@
 //! unpacker (`unpack_samples` in airspy.c). The IQ converters land
 //! here with the DSP milestone.
 
+/// Bytes per packed 32-bit word (`uint32_t *input` in
+/// `unpack_samples`, airspy.c).
+const WORD_BYTES: usize = 4;
 /// Bytes consumed per unpacked group — three 32-bit words (`i += 3`
 /// in `unpack_samples`, airspy.c).
-const BYTES_PER_GROUP: usize = 12;
+const BYTES_PER_GROUP: usize = 3 * WORD_BYTES;
 /// Samples produced per group (`j += 8` in `unpack_samples`,
 /// airspy.c).
 const SAMPLES_PER_GROUP: usize = 8;
@@ -60,8 +63,10 @@ pub(crate) fn unpack_samples(input: &[u8], output: &mut [u16]) -> usize {
     // 8-byte tail s0..s4 of the C layout above). This is how the port
     // reaches C's bytes*2/3 count without C's overrun.
     let mut written = groups * SAMPLES_PER_GROUP;
+    // Same bit expressions as the group loop above (s0..s4 of the C
+    // layout), applied to however many complete tail words exist.
     let tail = &input[groups * BYTES_PER_GROUP..];
-    if tail.len() >= 4 {
+    if tail.len() >= WORD_BYTES {
         let w0 = word(tail, 0);
         let mut push = |v: u32| {
             if let Some(slot) = output.get_mut(written) {
@@ -71,7 +76,7 @@ pub(crate) fn unpack_samples(input: &[u8], output: &mut [u16]) -> usize {
         };
         push((w0 >> 20) & 0xFFF);
         push((w0 >> 8) & 0xFFF);
-        if tail.len() >= 8 {
+        if tail.len() >= 2 * WORD_BYTES {
             let w1 = word(tail, 1);
             push(((w0 & 0xFF) << 4) | ((w1 >> 28) & 0xF));
             push((w1 & 0x0FFF_0000) >> 16);
@@ -190,7 +195,15 @@ pub(crate) fn convert_block<'a>(
         sample_type,
         SampleType::Raw | SampleType::Float32Iq | SampleType::Int16Iq
     ) {
-        return (Samples::Raw(bytes), bytes.len() / 2);
+        // C sets the packed sample_count before the RAW branch skips
+        // unpacking, so a packed RAW stream reports the unpacked
+        // count (174762 per full buffer), not bytes/2.
+        let count = if packing_enabled {
+            unpacked_sample_count(bytes.len())
+        } else {
+            bytes.len() / 2
+        };
+        return (Samples::Raw(bytes), count);
     }
     // C: packing_enabled && sample_type != RAW → unpack first.
     let words: &[u16] = if packing_enabled {
@@ -429,8 +442,10 @@ mod tests {
         assert_eq!(count, 8);
         assert!(matches!(samples, Samples::Int16(w) if w == [0i16; 8]));
 
-        // RAW skips the unpack even in packed mode.
-        let (samples, _) = convert_block(SampleType::Raw, true, &packed, &mut scratch);
+        // RAW skips the unpack even in packed mode, but reports the
+        // packed sample count like C (12 bytes → 8).
+        let (samples, count) = convert_block(SampleType::Raw, true, &packed, &mut scratch);
         assert!(matches!(samples, Samples::Raw(b) if b == packed.as_slice()));
+        assert_eq!(count, 8);
     }
 }

--- a/crates/libairspy/src/device.rs
+++ b/crates/libairspy/src/device.rs
@@ -54,11 +54,22 @@ const FALLBACK_SAMPLERATES: [u32; 2] = [10_000_000, 2_500_000];
 /// `airspy_get_samplerates` (airspy.c): non-IQ sample types — RAW
 /// included — see the firmware rates doubled
 /// (`!SAMPLE_TYPE_IS_IQ(device->sample_type)` → `buffer[i] *= 2`).
+/// The non-IQ rate multiplier in `airspy_get_samplerates`'s
+/// `buffer[i] *= 2` (airspy.c).
+const NON_IQ_RATE_FACTOR: u32 = 2;
+
 fn rates_for_sample_type(rates: &[u32], sample_type: SampleType) -> Vec<u32> {
     let is_iq = matches!(sample_type, SampleType::Float32Iq | SampleType::Int16Iq);
     rates
         .iter()
-        .map(|&r| if is_iq { r } else { r.saturating_mul(2) })
+        // wrapping_mul: C's uint32_t multiply wraps on overflow.
+        .map(|&r| {
+            if is_iq {
+                r
+            } else {
+                r.wrapping_mul(NON_IQ_RATE_FACTOR)
+            }
+        })
         .collect()
 }
 

--- a/crates/libairspy/src/device.rs
+++ b/crates/libairspy/src/device.rs
@@ -51,6 +51,17 @@ const fn serial_filter(serial_number: u64) -> Option<u64> {
 /// the firmware `AIRSPY_GET_SAMPLERATES` query fails.
 const FALLBACK_SAMPLERATES: [u32; 2] = [10_000_000, 2_500_000];
 
+/// `airspy_get_samplerates` (airspy.c): non-IQ sample types — RAW
+/// included — see the firmware rates doubled
+/// (`!SAMPLE_TYPE_IS_IQ(device->sample_type)` → `buffer[i] *= 2`).
+fn rates_for_sample_type(rates: &[u32], sample_type: SampleType) -> Vec<u32> {
+    let is_iq = matches!(sample_type, SampleType::Float32Iq | SampleType::Int16Iq);
+    rates
+        .iter()
+        .map(|&r| if is_iq { r } else { r.saturating_mul(2) })
+        .collect()
+}
+
 /// Cap on the firmware-reported rate count: a control transfer's
 /// wLength is a `u16`, so more than `u16::MAX / 4` words cannot
 /// arrive in one read (`airspy_read_samplerates_from_fw` in airspy.c
@@ -246,16 +257,15 @@ impl Device {
         Err(Error::NotFound)
     }
 
-    /// The supported sample rates cached at open
-    /// (`airspy_get_samplerates`; the C length/count two-call protocol
-    /// collapses into a slice).
+    /// The supported sample rates for the currently selected sample
+    /// type (`airspy_get_samplerates`; the C length/count two-call
+    /// protocol collapses into a Vec).
     ///
-    /// C doubles these values when a real (non-IQ) sample type is
-    /// selected; sample-type selection arrives with the streaming
-    /// engine, which revisits this.
+    /// Like C, every non-IQ type — including RAW — reports the cached
+    /// firmware rates doubled (`!SAMPLE_TYPE_IS_IQ` in airspy.c).
     #[must_use]
-    pub fn samplerates(&self) -> &[u32] {
-        &self.supported_samplerates
+    pub fn samplerates(&self) -> Vec<u32> {
+        rates_for_sample_type(&self.supported_samplerates, self.sample_type)
     }
 
     /// `airspy_read_samplerates_from_fw`: a 4-byte count query
@@ -535,6 +545,32 @@ mod samplerate_tests {
         // airspy_open_init's fallback when the firmware rate query
         // fails: {10000000, 2500000}.
         assert_eq!(FALLBACK_SAMPLERATES, [10_000_000, 2_500_000]);
+    }
+
+    #[test]
+    fn non_iq_types_double_the_rates_like_c() {
+        use crate::commands::SampleType;
+        let rates = [10_000_000, 2_500_000];
+        assert_eq!(
+            rates_for_sample_type(&rates, SampleType::Float32Iq),
+            vec![10_000_000, 2_500_000]
+        );
+        assert_eq!(
+            rates_for_sample_type(&rates, SampleType::Int16Iq),
+            vec![10_000_000, 2_500_000]
+        );
+        for t in [
+            SampleType::Float32Real,
+            SampleType::Int16Real,
+            SampleType::Uint16Real,
+            SampleType::Raw,
+        ] {
+            assert_eq!(
+                rates_for_sample_type(&rates, t),
+                vec![20_000_000, 5_000_000],
+                "non-IQ type {t:?} must double"
+            );
+        }
     }
 
     #[test]

--- a/crates/libairspy/src/device.rs
+++ b/crates/libairspy/src/device.rs
@@ -10,7 +10,7 @@ use rusb::UsbContext as _;
 
 use std::sync::Arc;
 
-use crate::commands::Command;
+use crate::commands::{Command, SampleType};
 use crate::error::{Error, Result};
 use crate::stream::StreamWorkers;
 
@@ -175,6 +175,9 @@ pub struct Device {
     handle: Arc<rusb::DeviceHandle<rusb::Context>>,
     supported_samplerates: Vec<u32>,
     workers: Option<StreamWorkers>,
+    sample_type: SampleType,
+    /// `device->packing_enabled` — toggled by the packing setter (M4).
+    pub(crate) packing_enabled: bool,
 }
 
 impl core::fmt::Debug for Device {
@@ -228,6 +231,10 @@ impl Device {
                 handle: Arc::new(handle),
                 supported_samplerates: Vec::new(),
                 workers: None,
+                // airspy_open_init: sample_type = AIRSPY_SAMPLE_FLOAT32_IQ,
+                // packing_enabled = false.
+                sample_type: SampleType::Float32Iq,
+                packing_enabled: false,
             };
             // airspy_open_init caches the firmware rate table at open,
             // falling back to a fixed pair when the query fails.
@@ -285,6 +292,21 @@ impl Device {
     /// Clone the shared USB handle for the reader thread.
     pub(crate) fn usb_handle_arc(&self) -> Arc<rusb::DeviceHandle<rusb::Context>> {
         Arc::clone(&self.handle)
+    }
+
+    /// Select the delivered sample format (`airspy_set_sample_type`).
+    ///
+    /// C assigns unconditionally and its consumer reads the field per
+    /// buffer (racing any mid-stream change); this port latches the
+    /// type when [`Device::start_rx`] runs — set it before starting.
+    pub fn set_sample_type(&mut self, sample_type: SampleType) {
+        self.sample_type = sample_type;
+    }
+
+    /// The currently selected sample format.
+    #[must_use]
+    pub fn sample_type(&self) -> SampleType {
+        self.sample_type
     }
 
     /// Streaming worker accessors for `stream.rs`.

--- a/crates/libairspy/src/device.rs
+++ b/crates/libairspy/src/device.rs
@@ -308,9 +308,15 @@ impl Device {
     ///
     /// C assigns unconditionally and its consumer reads the field per
     /// buffer (racing any mid-stream change); this port latches the
-    /// type when [`Device::start_rx`] runs — set it before starting.
-    pub fn set_sample_type(&mut self, sample_type: SampleType) {
+    /// type when [`Device::start_rx`] runs, so changing it during an
+    /// active stream is refused with [`Error::Busy`] rather than
+    /// silently deferred.
+    pub fn set_sample_type(&mut self, sample_type: SampleType) -> Result<()> {
+        if self.is_streaming() {
+            return Err(Error::Busy);
+        }
         self.sample_type = sample_type;
+        Ok(())
     }
 
     /// The currently selected sample format.
@@ -534,11 +540,6 @@ mod tests {
             Err(crate::Error::NotFound)
         ));
     }
-}
-
-#[cfg(test)]
-mod samplerate_tests {
-    use super::*;
 
     #[test]
     fn fallback_table_matches_c() {

--- a/crates/libairspy/src/lib.rs
+++ b/crates/libairspy/src/lib.rs
@@ -14,13 +14,14 @@
 
 pub mod board;
 pub mod commands;
-mod conversion;
+pub mod conversion;
 pub mod device;
 pub mod error;
 pub mod stream;
 mod transfer;
 
 pub use board::PartIdSerial;
+pub use conversion::Samples;
 pub use device::{Device, list_devices};
 pub use error::{Error, Result};
 

--- a/crates/libairspy/src/stream.rs
+++ b/crates/libairspy/src/stream.rs
@@ -225,7 +225,8 @@ pub(crate) fn run_consumer(
     packing_enabled: bool,
     callback: &mut (impl FnMut(Transfer<'_>) -> bool + ?Sized),
 ) {
-    let mut scratch = Scratch::default();
+    // Preallocated so the hot loop never grows a buffer.
+    let mut scratch = Scratch::for_stream(sample_type, packing_enabled, BUFFER_SIZE);
     while shared.running() {
         let Some((buf, dropped)) = shared.queue.pop_filled() else {
             break;
@@ -300,6 +301,16 @@ fn run_reader(shared: &StreamShared, handle: &rusb::DeviceHandle<rusb::Context>)
     shared.queue.shutdown();
 }
 
+/// The sample types `start_rx` accepts today. The IQ types return
+/// [`Error::Unsupported`] until the iqconverter ports land (M3
+/// removes this gate).
+fn validate_stream_sample_type(sample_type: SampleType) -> Result<()> {
+    if matches!(sample_type, SampleType::Float32Iq | SampleType::Int16Iq) {
+        return Err(Error::Unsupported);
+    }
+    Ok(())
+}
+
 /// Worker-thread handles held by a streaming [`Device`].
 pub(crate) struct StreamWorkers {
     pub(crate) shared: Arc<StreamShared>,
@@ -334,27 +345,9 @@ impl Device {
         callback: impl FnMut(Transfer<'_>) -> bool + Send + 'static,
     ) -> Result<()> {
         let sample_type = self.sample_type();
-        if matches!(sample_type, SampleType::Float32Iq | SampleType::Int16Iq) {
-            // Temporary until the iqconverter ports land (M3).
-            return Err(Error::Unsupported);
-        }
+        validate_stream_sample_type(sample_type)?;
         let packing_enabled = self.packing_enabled;
-        // C gates on `streaming || stop_requested` only, so a device
-        // whose callback stopped the stream can be restarted; reap
-        // finished workers before the busy check.
-        if let Some(mut workers) = self.take_stream_workers() {
-            if workers.shared.running() {
-                self.set_stream_workers(Some(workers));
-                return Err(Error::Busy);
-            }
-            workers.shared.queue.shutdown();
-            if let Some(t) = workers.reader.take() {
-                let _ = t.join();
-            }
-            if let Some(t) = workers.consumer.take() {
-                let _ = t.join();
-            }
-        }
+        self.reap_finished_workers()?;
         // Converter resets and drop-counter zeroing from
         // airspy_start_rx happen via fresh queue/converter state here.
         self.set_receiver_mode(ReceiverMode::Off)?;
@@ -399,6 +392,26 @@ impl Device {
             reader: Some(reader),
             consumer: Some(consumer),
         }));
+        Ok(())
+    }
+
+    /// C gates on `streaming || stop_requested` only, so a device
+    /// whose callback stopped the stream can be restarted; reap any
+    /// finished workers, or report [`Error::Busy`] for a live stream.
+    fn reap_finished_workers(&mut self) -> Result<()> {
+        if let Some(mut workers) = self.take_stream_workers() {
+            if workers.shared.running() {
+                self.set_stream_workers(Some(workers));
+                return Err(Error::Busy);
+            }
+            workers.shared.queue.shutdown();
+            if let Some(t) = workers.reader.take() {
+                let _ = t.join();
+            }
+            if let Some(t) = workers.consumer.take() {
+                let _ = t.join();
+            }
+        }
         Ok(())
     }
 
@@ -545,6 +558,26 @@ mod tests {
         std::thread::sleep(core::time::Duration::from_millis(50));
         q.shutdown();
         assert!(waiter.join().expect("join").is_none());
+    }
+
+    #[test]
+    fn start_rx_gate_rejects_iq_types_until_dsp_lands() {
+        assert!(matches!(
+            validate_stream_sample_type(SampleType::Float32Iq),
+            Err(crate::Error::Unsupported)
+        ));
+        assert!(matches!(
+            validate_stream_sample_type(SampleType::Int16Iq),
+            Err(crate::Error::Unsupported)
+        ));
+        for t in [
+            SampleType::Float32Real,
+            SampleType::Int16Real,
+            SampleType::Uint16Real,
+            SampleType::Raw,
+        ] {
+            assert!(validate_stream_sample_type(t).is_ok(), "{t:?} must pass");
+        }
     }
 
     #[test]

--- a/crates/libairspy/src/stream.rs
+++ b/crates/libairspy/src/stream.rs
@@ -21,7 +21,8 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use crate::commands::{Command, ReceiverMode};
+use crate::commands::{Command, ReceiverMode, SampleType};
+use crate::conversion::{Samples, Scratch, convert_block};
 use crate::device::Device;
 use crate::error::{Error, Result};
 
@@ -40,19 +41,15 @@ pub(crate) const BULK_ENDPOINT: u8 = 0x81;
 /// `struct timeval timeout = { 0, 500000 }` (airspy.c).
 pub(crate) const EVENT_TIMEOUT: Duration = Duration::from_millis(500);
 
-/// Bytes per raw sample word — `consumer_threadproc` computes
-/// `sample_count = buffer_size / 2` (airspy.c), one `uint16_t` each.
-const RAW_SAMPLE_BYTES: usize = 2;
-
 /// One delivered block of samples — the `airspy_transfer` view handed
 /// to the `airspy_start_rx` callback.
-///
-/// Until the sample-type pipeline lands, `samples` carries the raw
-/// bulk bytes (`AIRSPY_SAMPLE_RAW` semantics).
 #[derive(Debug)]
 pub struct Transfer<'a> {
-    /// Raw sample bytes for this block.
-    pub samples: &'a [u8],
+    /// Samples in the format selected before `start_rx`
+    /// (`airspy_transfer.samples` + `sample_type`).
+    pub samples: Samples<'a>,
+    /// The latched sample type for this stream.
+    pub sample_type: SampleType,
     /// `dropped_buffers * sample_count` — samples lost to a full ring
     /// since the previous delivery (`airspy_transfer.dropped_samples`).
     pub dropped_samples: u64,
@@ -219,16 +216,16 @@ impl StreamShared {
     }
 }
 
-/// `consumer_threadproc`: pop filled buffers, hand them to the
-/// callback, recycle. A `false` return stops streaming. Sample-type
-/// conversion slots in here when the pipeline lands.
+/// `consumer_threadproc`: pop filled buffers, run the sample-type
+/// dispatch, hand the typed block to the callback, recycle. A `false`
+/// return stops streaming.
 pub(crate) fn run_consumer(
     shared: &StreamShared,
+    sample_type: SampleType,
+    packing_enabled: bool,
     callback: &mut (impl FnMut(Transfer<'_>) -> bool + ?Sized),
 ) {
-    // C computes dropped_samples as dropped_buffers * sample_count
-    // where sample_count is the u16 count per buffer.
-    let sample_count = (BUFFER_SIZE / RAW_SAMPLE_BYTES) as u64;
+    let mut scratch = Scratch::default();
     while shared.running() {
         let Some((buf, dropped)) = shared.queue.pop_filled() else {
             break;
@@ -239,9 +236,14 @@ pub(crate) fn run_consumer(
             shared.queue.recycle(buf);
             break;
         }
+        let (samples, sample_count) =
+            convert_block(sample_type, packing_enabled, &buf, &mut scratch);
+        // C: dropped_samples = dropped_buffers * sample_count, with
+        // the block's own converted count.
         let keep_going = callback(Transfer {
-            samples: &buf,
-            dropped_samples: u64::from(dropped) * sample_count,
+            samples,
+            sample_type,
+            dropped_samples: u64::from(dropped) * sample_count as u64,
         });
         shared.queue.recycle(buf);
         if !keep_going {
@@ -321,12 +323,22 @@ impl Device {
     /// bulk endpoint halt, receiver on, then spawn the reader and
     /// consumer threads. Returns [`Error::Busy`] while streaming.
     ///
+    /// The sample type and packing mode are latched here (see
+    /// [`Device::set_sample_type`]). The IQ sample types return
+    /// [`Error::Unsupported`] until the DSP converters land.
+    ///
     /// The callback runs on the consumer thread; return `true` to
     /// keep streaming, `false` to stop (C's nonzero-return stop).
     pub fn start_rx(
         &mut self,
         callback: impl FnMut(Transfer<'_>) -> bool + Send + 'static,
     ) -> Result<()> {
+        let sample_type = self.sample_type();
+        if matches!(sample_type, SampleType::Float32Iq | SampleType::Int16Iq) {
+            // Temporary until the iqconverter ports land (M3).
+            return Err(Error::Unsupported);
+        }
+        let packing_enabled = self.packing_enabled;
         // C gates on `streaming || stop_requested` only, so a device
         // whose callback stopped the stream can be restarted; reap
         // finished workers before the busy check.
@@ -357,7 +369,7 @@ impl Device {
         let mut cb = callback;
         let consumer_spawn = std::thread::Builder::new()
             .name("airspy-consumer".into())
-            .spawn(move || run_consumer(&consumer_shared, &mut cb));
+            .spawn(move || run_consumer(&consumer_shared, sample_type, packing_enabled, &mut cb));
         let Ok(consumer) = consumer_spawn else {
             // Hardening beyond C (which leaves the receiver running
             // until stop/close after a thread-create failure): switch
@@ -553,10 +565,18 @@ mod tests {
         let mut seen = Vec::new();
         let shared2 = Arc::clone(&shared);
         let consumer = std::thread::spawn(move || {
-            run_consumer(&shared2, &mut |transfer: Transfer<'_>| {
-                seen.push((transfer.samples[0], transfer.dropped_samples));
-                seen.len() < 2 // stop after the second delivery
-            });
+            run_consumer(
+                &shared2,
+                SampleType::Raw,
+                false,
+                &mut |transfer: Transfer<'_>| {
+                    let Samples::Raw(bytes) = transfer.samples else {
+                        unreachable!("RAW stream delivers raw bytes");
+                    };
+                    seen.push((bytes[0], transfer.dropped_samples));
+                    seen.len() < 2 // stop after the second delivery
+                },
+            );
             seen
         });
 


### PR DESCRIPTION
Closes #12. Wires the #11 unpacker into the consumer and gives the callback its typed face.

- **`Samples` enum** (`Float32`/`Int16`/`Uint16`/`Raw`) — the typed replacement for C's `airspy_transfer.samples` `void*` + `sample_type` pair; `Transfer` now carries `samples`, `sample_type`, and `dropped_samples` computed with the block's own converted count (C parity).
- **`convert_block`** ports `consumer_threadproc`'s dispatch: packing && !RAW → 12-bit unpack; then `convert_samples_int16` (`(src-2048) << SAMPLE_SHIFT`) / `convert_samples_float` (`(src-2048) * SAMPLE_SCALE`, 1/2048) / `Uint16` word passthrough / RAW byte passthrough. Reusable `Scratch` buffers mirror C's `unpacked_samples`/`output_buffer` — zero steady-state allocation.
- **`Device::set_sample_type`** (`airspy_set_sample_type`, default `Float32Iq` per `airspy_open_init`). Documented deviation: C's consumer reads the field live per buffer, racing mid-stream changes; this port latches at `start_rx`.
- **IQ types** (`Float32Iq`/`Int16Iq`) return `Error::Unsupported` from `start_rx` until the M3 iqconverter ports land — the dispatch has their seam ready.
- `packing_enabled` field plumbed (always false until the M4 setter).

TDD: 8 new tests written first and watched fail — SHIFT/SCALE constant pins, int16/float conversion arithmetic against hand-computed C values, and dispatch behavior per type including packed-mode unpack-then-convert and RAW's unpack bypass. 60 tests green, workspace clippy `-D warnings` all features, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for converting Airspy stream data into Float32, Int16, Uint16, or raw byte samples.
  * Added sample type selection and inspection for devices.
  * Streaming transfers now provide typed samples and sample type information.
  * Added support for packed sample data and adjusted sample rates for non-IQ formats.

* **Bug Fixes**
  * Improved handling of partial packed-data tails, endian decoding, and dropped-sample counts.
  * Prevented sample-type changes while streaming and rejected unsupported IQ configurations.

* **Tests**
  * Added coverage for conversion, scaling, decoding, dispatch, and streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->