### PR TITLE
M2: tokio + smol async Stream adapters

### DIFF
--- a/crates/libairspy/src/lib.rs
+++ b/crates/libairspy/src/lib.rs
@@ -19,6 +19,10 @@ pub mod device;
 pub mod error;
 pub mod reader;
 pub mod stream;
+#[cfg(feature = "smol")]
+pub mod stream_smol;
+#[cfg(feature = "tokio")]
+pub mod stream_tokio;
 mod transfer;
 
 pub use board::PartIdSerial;

--- a/crates/libairspy/src/stream_smol.rs
+++ b/crates/libairspy/src/stream_smol.rs
@@ -1,0 +1,98 @@
+//! Smol `Stream` adapter — gated on `feature = "smol"`, mirroring
+//! librtlsdr-rs's per-runtime bridge shape (`async-channel`'s
+//! `Receiver` already implements `Stream`; `blocking` is not needed
+//! because this engine owns its own threads).
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use async_channel::{Receiver, Sender};
+use futures_core::Stream;
+
+use crate::device::Device;
+use crate::error::Result;
+use crate::reader::OwnedTransfer;
+use crate::stream::{RAW_BUFFER_COUNT, Transfer};
+
+/// The consumer-side bridge — see the tokio twin; identical policy.
+fn forward_smol(tx: &Sender<OwnedTransfer>, transfer: Transfer<'_>) -> bool {
+    tx.send_blocking(OwnedTransfer::from(transfer)).is_ok()
+}
+
+/// Async sample stream for smol (and any runtime-agnostic) consumers;
+/// created by [`Device::rx_stream_smol`]. Dropping it stops the
+/// stream (`airspy_stop_rx` semantics).
+#[derive(Debug)]
+pub struct SmolTransferStream<'d> {
+    device: &'d mut Device,
+    /// `Option` so `Drop` can disconnect the channel BEFORE joining
+    /// the workers (the PR #53 deadlock ordering); boxed-pinned
+    /// because `async_channel::Receiver` is `!Unpin`.
+    rx: Option<Pin<Box<Receiver<OwnedTransfer>>>>,
+}
+
+impl Stream for SmolTransferStream<'_> {
+    type Item = OwnedTransfer;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<OwnedTransfer>> {
+        match self.rx.as_mut() {
+            Some(rx) => rx.as_mut().poll_next(cx),
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+impl Drop for SmolTransferStream<'_> {
+    fn drop(&mut self) {
+        drop(self.rx.take());
+        let _ = self.device.stop_rx();
+    }
+}
+
+impl Device {
+    /// Start streaming and return a runtime-agnostic async `Stream`
+    /// of owned sample blocks — the smol counterpart of
+    /// [`Device::rx_stream_tokio`], with identical backpressure and
+    /// drop accounting.
+    pub fn rx_stream_smol(&mut self) -> Result<SmolTransferStream<'_>> {
+        let (tx, rx) = async_channel::bounded(RAW_BUFFER_COUNT);
+        self.start_rx(move |transfer| forward_smol(&tx, transfer))?;
+        Ok(SmolTransferStream {
+            device: self,
+            rx: Some(Box::pin(rx)),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::SampleType;
+    use crate::conversion::Samples;
+    use crate::reader::SampleBlock;
+    use crate::stream::Transfer;
+
+    fn raw_transfer(bytes: &'static [u8]) -> Transfer<'static> {
+        Transfer {
+            samples: Samples::Raw(bytes),
+            sample_type: SampleType::Raw,
+            dropped_samples: 9,
+        }
+    }
+
+    #[test]
+    fn forwards_blocks_while_receiver_lives() {
+        let (tx, rx) = async_channel::bounded(2);
+        assert!(forward_smol(&tx, raw_transfer(&[4, 5])));
+        let got = rx.recv_blocking().expect("delivered");
+        assert_eq!(got.dropped_samples, 9);
+        assert!(matches!(got.samples, SampleBlock::Raw(ref b) if b.as_slice() == [4, 5]));
+    }
+
+    #[test]
+    fn stops_when_receiver_dropped() {
+        let (tx, rx) = async_channel::bounded::<crate::reader::OwnedTransfer>(1);
+        drop(rx);
+        assert!(!forward_smol(&tx, raw_transfer(&[6])));
+    }
+}

--- a/crates/libairspy/src/stream_tokio.rs
+++ b/crates/libairspy/src/stream_tokio.rs
@@ -1,0 +1,104 @@
+//! Tokio `Stream` adapter — gated on `feature = "tokio"`, mirroring
+//! librtlsdr-rs's per-runtime bridge shape.
+//!
+//! Unlike librtlsdr-rs (whose pull iterator needs
+//! `tokio::task::spawn_blocking`), this engine already owns its reader
+//! and consumer threads, so the adapter is a channel bridge off the
+//! [`crate::Device::start_rx`] callback: `blocking_send` from the
+//! consumer thread, `poll_recv` on the async side. No runtime is
+//! required to create the stream — only to poll it.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::Stream;
+use tokio::sync::mpsc::{Receiver, Sender};
+
+use crate::device::Device;
+use crate::error::Result;
+use crate::reader::OwnedTransfer;
+use crate::stream::{RAW_BUFFER_COUNT, Transfer};
+
+/// The consumer-side bridge: `false` (stop streaming) once the stream
+/// is dropped; a full channel blocks, pushing overflow into the
+/// ring's C drop accounting — same policy as the sync reader.
+fn forward_tokio(tx: &Sender<OwnedTransfer>, transfer: Transfer<'_>) -> bool {
+    tx.blocking_send(OwnedTransfer::from(transfer)).is_ok()
+}
+
+/// Async sample stream for tokio consumers; created by
+/// [`Device::rx_stream_tokio`]. Dropping it stops the stream
+/// (`airspy_stop_rx` semantics).
+#[derive(Debug)]
+pub struct TokioTransferStream<'d> {
+    device: &'d mut Device,
+    /// `Option` so `Drop` can disconnect the channel BEFORE joining
+    /// the workers (the PR #53 deadlock ordering).
+    rx: Option<Receiver<OwnedTransfer>>,
+}
+
+impl Stream for TokioTransferStream<'_> {
+    type Item = OwnedTransfer;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<OwnedTransfer>> {
+        match self.rx.as_mut() {
+            Some(rx) => rx.poll_recv(cx),
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+impl Drop for TokioTransferStream<'_> {
+    fn drop(&mut self) {
+        drop(self.rx.take());
+        let _ = self.device.stop_rx();
+    }
+}
+
+impl Device {
+    /// Start streaming and return a tokio-friendly async `Stream` of
+    /// owned sample blocks — the async counterpart of
+    /// [`Device::rx_blocks`], with identical backpressure and drop
+    /// accounting.
+    pub fn rx_stream_tokio(&mut self) -> Result<TokioTransferStream<'_>> {
+        let (tx, rx) = tokio::sync::mpsc::channel(RAW_BUFFER_COUNT);
+        self.start_rx(move |transfer| forward_tokio(&tx, transfer))?;
+        Ok(TokioTransferStream {
+            device: self,
+            rx: Some(rx),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::SampleType;
+    use crate::conversion::Samples;
+    use crate::reader::SampleBlock;
+    use crate::stream::Transfer;
+
+    fn raw_transfer(bytes: &'static [u8]) -> Transfer<'static> {
+        Transfer {
+            samples: Samples::Raw(bytes),
+            sample_type: SampleType::Raw,
+            dropped_samples: 5,
+        }
+    }
+
+    #[test]
+    fn forwards_blocks_while_receiver_lives() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(2);
+        assert!(forward_tokio(&tx, raw_transfer(&[1, 2])));
+        let got = rx.blocking_recv().expect("delivered");
+        assert_eq!(got.dropped_samples, 5);
+        assert!(matches!(got.samples, SampleBlock::Raw(ref b) if b.as_slice() == [1, 2]));
+    }
+
+    #[test]
+    fn stops_when_receiver_dropped() {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        drop(rx);
+        assert!(!forward_tokio(&tx, raw_transfer(&[3])));
+    }
+}


### PR DESCRIPTION
Closes #14, closes #15 — bundled per Jason: the two adapters are twins and complete M2's API surface.

- **`Device::rx_stream_tokio()`** (`tokio` feature): `futures_core::Stream` of `OwnedTransfer` via `tokio::sync::mpsc` — `blocking_send` on the consumer thread, `poll_recv` on the async side. No runtime needed to *create* the stream, only to poll it (unlike librtlsdr-rs, whose pull iterator needs `spawn_blocking` + a runtime preflight — our engine owns its threads, so the adapters collapse to channel bridges).
- **`Device::rx_stream_smol()`** (`smol` feature): same shape over `async-channel` (whose `Receiver` implements `Stream`; boxed-pinned since it's `!Unpin`). The `blocking` crate dependency turned out unnecessary for our engine shape and stays unused (removable in a follow-up if it never earns its keep).
- Both inherit the established policies: bounded at `RAW_BUFFER_COUNT` with overflow flowing into the ring's C drop accounting, dropped-stream → callback-false stop, and the PR #53 drop-receiver-before-join ordering to prevent the shutdown deadlock.
- The CI "Feature combinations (tokio)"/"(smol)" jobs now compile real adapter code for the first time.

TDD: 4 bridge tests written first and watched fail (delivery with drop-count preservation + disconnected-receiver stop, per runtime). Verified locally across all four feature combos (none, tokio, smol, both) — 70/72/72/74 tests green; workspace clippy `-D warnings` all features; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asynchronous transfer streams for Tokio and smol runtimes.
  * Tokio streams integrate with the standard asynchronous `Stream` interface.
  * Added bounded buffering to support backpressure during data transfer.
  * Streams automatically stop receiving when consumers disconnect or streams are dropped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->