### PR TITLE
M3: iqconverter_float port — all six sample types live

### DIFF
--- a/crates/libairspy/src/conversion.rs
+++ b/crates/libairspy/src/conversion.rs
@@ -101,12 +101,13 @@ pub(crate) const fn unpacked_sample_count(len: usize) -> usize {
 }
 
 use crate::commands::SampleType;
-use crate::filters::HB_KERNEL_INT16;
+use crate::filters::{HB_KERNEL_FLOAT, HB_KERNEL_INT16};
 
 /// Values per complex sample — IQ slices interleave I and Q, and C
 /// halves `sample_count` for the IQ types (`consumer_threadproc`,
 /// airspy.c).
 const IQ_COMPONENTS: usize = 2;
+use crate::iqconverter_float::IqConverterFloat;
 use crate::iqconverter_int16::IqConverterInt16;
 
 /// `SAMPLE_SHIFT` (airspy.c): `SAMPLE_ENCAPSULATION (16) -
@@ -139,11 +140,11 @@ fn convert_samples_float(src: &[u16], dest: &mut [f32]) {
 /// `void*`.
 #[derive(Debug)]
 pub enum Samples<'a> {
-    /// `AIRSPY_SAMPLE_FLOAT32_REAL` (and, with the DSP milestone,
-    /// `FLOAT32_IQ`).
+    /// `AIRSPY_SAMPLE_FLOAT32_REAL` / `AIRSPY_SAMPLE_FLOAT32_IQ`
+    /// (IQ slices interleave I and Q).
     Float32(&'a [f32]),
-    /// `AIRSPY_SAMPLE_INT16_REAL` (and, with the DSP milestone,
-    /// `INT16_IQ`).
+    /// `AIRSPY_SAMPLE_INT16_REAL` / `AIRSPY_SAMPLE_INT16_IQ`
+    /// (IQ slices interleave I and Q).
     Int16(&'a [i16]),
     /// `AIRSPY_SAMPLE_UINT16_REAL` — raw ADC words.
     Uint16(&'a [u16]),
@@ -162,6 +163,7 @@ pub(crate) struct Scratch {
     out_i16: Vec<i16>,
     out_f32: Vec<f32>,
     cnv_i: IqConverterInt16,
+    cnv_f: IqConverterFloat,
 }
 
 impl Default for Scratch {
@@ -172,6 +174,7 @@ impl Default for Scratch {
             out_i16: Vec::new(),
             out_f32: Vec::new(),
             cnv_i: IqConverterInt16::new(&HB_KERNEL_INT16),
+            cnv_f: IqConverterFloat::new(&HB_KERNEL_FLOAT),
         }
     }
 }
@@ -212,19 +215,14 @@ impl Scratch {
 /// typed samples plus the sample count C would report for the block —
 /// halved for IQ types, whose slices hold `count` interleaved I/Q
 /// pairs (`2 × count` values).
-///
-/// `Float32Iq` is absent until its converter lands (the streaming
-/// engine rejects it at `start_rx`).
 pub(crate) fn convert_block<'a>(
     sample_type: SampleType,
     packing_enabled: bool,
     bytes: &'a [u8],
     scratch: &'a mut Scratch,
 ) -> (Samples<'a>, usize) {
-    // RAW (and the not-yet-supported Float32Iq, which start_rx
-    // refuses and which degrades to RAW delivery here) bypasses all
-    // preparation.
-    if matches!(sample_type, SampleType::Raw | SampleType::Float32Iq) {
+    // RAW bypasses all preparation.
+    if matches!(sample_type, SampleType::Raw) {
         // C sets the packed sample_count before the RAW branch skips
         // unpacking, so a packed RAW stream reports the unpacked
         // count (174762 per full buffer), not bytes/2.
@@ -244,6 +242,7 @@ pub(crate) fn convert_block<'a>(
         out_i16,
         out_f32,
         cnv_i,
+        cnv_f,
     } = scratch;
     let src: &[u16] = if packing_enabled {
         &unpacked[..words_len]
@@ -251,8 +250,15 @@ pub(crate) fn convert_block<'a>(
         &words[..words_len]
     };
     match sample_type {
-        SampleType::Raw | SampleType::Float32Iq => {
-            unreachable!("handled by the early return above")
+        SampleType::Raw => unreachable!("handled by the early return above"),
+        SampleType::Float32Iq => {
+            // C: convert_samples_float → iqconverter_float_process →
+            // sample_count /= 2; complete pairs only, like Int16Iq.
+            out_f32.resize(words_len, 0.0);
+            convert_samples_float(src, out_f32);
+            cnv_f.process(out_f32);
+            let pairs = words_len / IQ_COMPONENTS;
+            (Samples::Float32(&out_f32[..pairs * IQ_COMPONENTS]), pairs)
         }
         SampleType::Int16Iq => {
             // C: convert_samples_int16 → iqconverter_int16_process →
@@ -564,6 +570,42 @@ mod tests {
         assert_eq!(count, 2);
         let Samples::Int16(out) = samples else {
             unreachable!("Int16Iq delivers i16 samples");
+        };
+        assert_eq!(out.len(), 4, "only complete IQ pairs delivered");
+    }
+
+    #[test]
+    fn dispatch_float32_iq_matches_golden_vectors() {
+        use crate::test_vectors::load_scenario;
+        let v = load_scenario("noise");
+        let mut scratch = Scratch::default();
+        for block in 0..3 {
+            let range = block * 2048..(block + 1) * 2048;
+            let bytes: Vec<u8> = v.input[range.clone()]
+                .iter()
+                .flat_map(|&w| w.to_le_bytes())
+                .collect();
+            let (samples, count) =
+                convert_block(SampleType::Float32Iq, false, &bytes, &mut scratch);
+            assert_eq!(count, 1024, "IQ halves the sample count");
+            let Samples::Float32(out) = samples else {
+                unreachable!("Float32Iq delivers f32 samples");
+            };
+            let got: Vec<u32> = out.iter().map(|f| f.to_bits()).collect();
+            let want: Vec<u32> = v.float[range].iter().map(|f| f.to_bits()).collect();
+            assert_eq!(got, want, "block {block} mismatch");
+        }
+    }
+
+    #[test]
+    fn dispatch_float32_iq_delivers_only_complete_pairs() {
+        let packed_tail: [u8; 8] = [0x78, 0x56, 0x34, 0x12, 0xF0, 0xDE, 0xBC, 0x9A];
+        let mut scratch = Scratch::default();
+        let (samples, count) =
+            convert_block(SampleType::Float32Iq, true, &packed_tail, &mut scratch);
+        assert_eq!(count, 2);
+        let Samples::Float32(out) = samples else {
+            unreachable!("Float32Iq delivers f32 samples");
         };
         assert_eq!(out.len(), 4, "only complete IQ pairs delivered");
     }

--- a/crates/libairspy/src/filters.rs
+++ b/crates/libairspy/src/filters.rs
@@ -15,3 +15,41 @@ pub(crate) const HB_KERNEL_INT16: [i16; HB_KERNEL_INT16_LEN] = [
     1885, 0, -1220, 0, 829, 0, -571, 0, 389, 0, -259, 0, 166, 0,
     -100, 0, 56, 0, -33,
 ];
+
+/// `HB_KERNEL_FLOAT_LEN` — `#define HB_KERNEL_FLOAT_LEN 47`
+/// (`filters.h`, `airspyone_host` @ `bd15be38`).
+pub(crate) const HB_KERNEL_FLOAT_LEN: usize = 47;
+
+/// `HB_KERNEL_FLOAT` (`filters.h`) — the same half-band low-pass in
+/// float. The C initializers are unsuffixed double literals narrowed
+/// to float; the `f64 → f32` casts and full-precision digits
+/// reproduce that exact conversion path (hence the precision allow).
+#[allow(clippy::cast_possible_truncation, clippy::excessive_precision)]
+#[rustfmt::skip]
+pub(crate) const HB_KERNEL_FLOAT: [f32; HB_KERNEL_FLOAT_LEN] = [
+    -0.000_998_606_272_947_510_f64 as f32, 0.0,
+    0.001_695_637_278_417_295_f64 as f32, 0.0,
+    -0.003_054_430_179_754_289_f64 as f32, 0.0,
+    0.005_055_504_379_767_936_f64 as f32, 0.0,
+    -0.007_901_319_195_893_647_f64 as f32, 0.0,
+    0.011_873_357_051_047_719_f64 as f32, 0.0,
+    -0.017_411_159_379_930_066_f64 as f32, 0.0,
+    0.025_304_817_427_568_772_f64 as f32, 0.0,
+    -0.037_225_225_204_559_217_f64 as f32, 0.0,
+    0.057_533_286_997_004_301_f64 as f32, 0.0,
+    -0.102_327_462_004_259_350_f64 as f32, 0.0,
+    0.317_034_472_508_947_400_f64 as f32,
+    0.5,
+    0.317_034_472_508_947_400_f64 as f32, 0.0,
+    -0.102_327_462_004_259_350_f64 as f32, 0.0,
+    0.057_533_286_997_004_301_f64 as f32, 0.0,
+    -0.037_225_225_204_559_217_f64 as f32, 0.0,
+    0.025_304_817_427_568_772_f64 as f32, 0.0,
+    -0.017_411_159_379_930_066_f64 as f32, 0.0,
+    0.011_873_357_051_047_719_f64 as f32, 0.0,
+    -0.007_901_319_195_893_647_f64 as f32, 0.0,
+    0.005_055_504_379_767_936_f64 as f32, 0.0,
+    -0.003_054_430_179_754_289_f64 as f32, 0.0,
+    0.001_695_637_278_417_295_f64 as f32, 0.0,
+    -0.000_998_606_272_947_510_f64 as f32,
+];

--- a/crates/libairspy/src/iqconverter_float.rs
+++ b/crates/libairspy/src/iqconverter_float.rs
@@ -22,6 +22,12 @@ const SIZE_FACTOR: usize = 32;
 /// `SCALE` (`iqconverter_float.c`) — the DC-removal averaging factor.
 const DC_SCALE: f32 = 0.01;
 
+/// The kernel lengths with dedicated symmetric-pair FIR
+/// specializations — the `case 4/8/12/24` labels of
+/// `fir_interleaved`'s switch (`iqconverter_float.c`); other lengths
+/// take the generic path.
+const SYMMETRIC_FIR_LENGTHS: [usize; 4] = [4, 8, 12, 24];
+
 /// `iqconverter_float_t` — the converter's persistent state.
 #[derive(Debug)]
 pub(crate) struct IqConverterFloat {
@@ -152,9 +158,10 @@ impl IqConverterFloat {
     /// share the symmetric-pair form; everything else takes the
     /// generic path.
     fn fir_interleaved(&mut self, samples: &mut [f32]) {
-        match self.fir_kernel.len() {
-            4 | 8 | 12 | 24 => self.fir_symmetric(samples),
-            _ => self.fir_generic(samples),
+        if SYMMETRIC_FIR_LENGTHS.contains(&self.fir_kernel.len()) {
+            self.fir_symmetric(samples);
+        } else {
+            self.fir_generic(samples);
         }
     }
 
@@ -206,9 +213,9 @@ impl IqConverterFloat {
     }
 }
 
-/// Compile-time tie between the stock kernel length and the `len = 24`
-/// FIR specialization the module docs promise.
-const _: () = assert!(HB_KERNEL_FLOAT_LEN / 2 + 1 == 24);
+/// Compile-time tie between the stock kernel length and the largest
+/// FIR specialization (`len = 24`) the module docs promise.
+const _: () = assert!(HB_KERNEL_FLOAT_LEN / 2 + 1 == SYMMETRIC_FIR_LENGTHS[3]);
 
 #[cfg(test)]
 mod tests {

--- a/crates/libairspy/src/iqconverter_float.rs
+++ b/crates/libairspy/src/iqconverter_float.rs
@@ -1,0 +1,279 @@
+//! Floating-point IQ converter, a faithful port of
+//! `iqconverter_float.c` from `airspyone_host` at the all-MIT
+//! reference revision `bd15be38` (MIT License, Copyright (C) 2014,
+//! Youssef Touil — full license text in `iqconverter_int16.rs` and
+//! NOTICE; both converters share it).
+//!
+//! Pipeline (interleaved in place, like the int16 twin): scalar DC
+//! removal → fs/4 translation (center-tap scaling on the Q phases) →
+//! half-band FIR on I + compensating delay on Q. The reference builds
+//! on Linux/GCC compile the scalar paths (neither `USE_SSE2` nor
+//! `FIR_STANDARD` is defined there), and with the stock 47-tap kernel
+//! (`len` = 24) the FIR dispatch selects `fir_interleaved_24`, whose
+//! symmetric-pair summation order this port reproduces term for term
+//! so results stay bit-exact against the golden vectors.
+
+use crate::filters::HB_KERNEL_FLOAT_LEN;
+
+/// `SIZE_FACTOR` (`iqconverter_float.c`) — FIR queue length multiplier
+/// (note: 32 here, unlike the int16 converter's 16).
+const SIZE_FACTOR: usize = 32;
+
+/// `SCALE` (`iqconverter_float.c`) — the DC-removal averaging factor.
+const DC_SCALE: f32 = 0.01;
+
+/// `iqconverter_float_t` — the converter's persistent state.
+#[derive(Debug)]
+pub(crate) struct IqConverterFloat {
+    /// Non-zero half-band taps (`hb_kernel[j]`, even `j`), `len/2 + 1`.
+    fir_kernel: Vec<f32>,
+    /// Sliding FIR history, `len * SIZE_FACTOR` entries.
+    fir_queue: Vec<f32>,
+    /// Q-branch compensating delay, `len / 2` entries.
+    delay_line: Vec<f32>,
+    /// `hbc` — the kernel's center tap (`hb_kernel[len / 2]`), used to
+    /// scale the Q phases in `translate_fs_4`.
+    hbc: f32,
+    fir_index: usize,
+    delay_index: usize,
+    /// `avg` — the DC-removal running average.
+    avg: f32,
+}
+
+impl IqConverterFloat {
+    /// `iqconverter_float_create`.
+    pub(crate) fn new(hb_kernel: &[f32]) -> Self {
+        let len = hb_kernel.len() / 2 + 1;
+        Self {
+            fir_kernel: hb_kernel.iter().step_by(2).copied().collect(),
+            fir_queue: vec![0.0; len * SIZE_FACTOR],
+            delay_line: vec![0.0; len / 2],
+            hbc: hb_kernel[hb_kernel.len() / 2],
+            fir_index: 0,
+            delay_index: 0,
+            avg: 0.0,
+        }
+    }
+
+    /// `iqconverter_float_reset` — correct upstream (unlike the int16
+    /// twin's), transcribed as-is.
+    // Part of the C surface; the streaming engine resets via fresh
+    // Scratch state, and the custom-kernel path (M4) calls this.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn reset(&mut self) {
+        self.avg = 0.0;
+        self.fir_index = 0;
+        self.delay_index = 0;
+        self.delay_line.fill(0.0);
+        self.fir_queue.fill(0.0);
+    }
+
+    /// The symmetric-pair FIR shared by C's `fir_interleaved_4/8/12/24`
+    /// specializations: `Σ kernel[k] * (queue[k] + queue[n-1-k])`,
+    /// summed left-to-right exactly as the C expressions chain.
+    fn fir_symmetric(&mut self, samples: &mut [f32]) {
+        let n = self.fir_kernel.len();
+        let half = n / 2;
+        let mut fir_index = self.fir_index;
+        for i in (0..samples.len()).step_by(2) {
+            self.fir_queue[fir_index] = samples[i];
+            let queue = &self.fir_queue[fir_index..fir_index + n];
+
+            let mut acc = 0.0f32;
+            for k in 0..half {
+                acc += self.fir_kernel[k] * (queue[k] + queue[n - 1 - k]);
+            }
+            samples[i] = acc;
+
+            if fir_index == 0 {
+                fir_index = n * (SIZE_FACTOR - 1);
+                self.fir_queue.copy_within(0..n - 1, fir_index + 1);
+            } else {
+                fir_index -= 1;
+            }
+        }
+        self.fir_index = fir_index;
+    }
+
+    /// `process_fir_taps` (the generic path for custom kernel lengths
+    /// that are not 4/8/12/24): a straight dot product in C's exact
+    /// grouping — 8-tap blocks, then a 4-tap block, then a 2-tap
+    /// remainder; a final odd tap is dead code upstream (commented
+    /// out) and therefore ignored here too.
+    fn process_fir_taps(kernel: &[f32], queue: &[f32]) -> f32 {
+        let mut sum = 0.0f32;
+        let mut len = kernel.len();
+        let mut k = 0usize;
+        while len >= 8 {
+            sum += kernel[k] * queue[k]
+                + kernel[k + 1] * queue[k + 1]
+                + kernel[k + 2] * queue[k + 2]
+                + kernel[k + 3] * queue[k + 3]
+                + kernel[k + 4] * queue[k + 4]
+                + kernel[k + 5] * queue[k + 5]
+                + kernel[k + 6] * queue[k + 6]
+                + kernel[k + 7] * queue[k + 7];
+            k += 8;
+            len -= 8;
+        }
+        if len >= 4 {
+            sum += kernel[k] * queue[k]
+                + kernel[k + 1] * queue[k + 1]
+                + kernel[k + 2] * queue[k + 2]
+                + kernel[k + 3] * queue[k + 3];
+            k += 4;
+            len -= 4;
+        }
+        if len >= 2 {
+            sum += kernel[k] * queue[k] + kernel[k + 1] * queue[k + 1];
+        }
+        sum
+    }
+
+    /// `fir_interleaved_generic` for custom kernels.
+    fn fir_generic(&mut self, samples: &mut [f32]) {
+        let n = self.fir_kernel.len();
+        let mut fir_index = self.fir_index;
+        for i in (0..samples.len()).step_by(2) {
+            self.fir_queue[fir_index] = samples[i];
+            samples[i] =
+                Self::process_fir_taps(&self.fir_kernel, &self.fir_queue[fir_index..fir_index + n]);
+            if fir_index == 0 {
+                fir_index = n * (SIZE_FACTOR - 1);
+                self.fir_queue.copy_within(0..n - 1, fir_index + 1);
+            } else {
+                fir_index -= 1;
+            }
+        }
+        self.fir_index = fir_index;
+    }
+
+    /// `fir_interleaved`'s dispatch: the 4/8/12/24 specializations all
+    /// share the symmetric-pair form; everything else takes the
+    /// generic path.
+    fn fir_interleaved(&mut self, samples: &mut [f32]) {
+        match self.fir_kernel.len() {
+            4 | 8 | 12 | 24 => self.fir_symmetric(samples),
+            _ => self.fir_generic(samples),
+        }
+    }
+
+    /// `delay_interleaved` over the Q (odd) samples.
+    fn delay_interleaved(&mut self, samples: &mut [f32]) {
+        let half_len = self.delay_line.len();
+        let mut index = self.delay_index;
+        for i in (1..samples.len()).step_by(2) {
+            core::mem::swap(&mut self.delay_line[index], &mut samples[i]);
+            index += 1;
+            if index >= half_len {
+                index = 0;
+            }
+        }
+        self.delay_index = index;
+    }
+
+    /// `remove_dc`: running-average DC removal.
+    fn remove_dc(&mut self, samples: &mut [f32]) {
+        let mut avg = self.avg;
+        for s in samples.iter_mut() {
+            *s -= avg;
+            avg += DC_SCALE * *s;
+        }
+        self.avg = avg;
+    }
+
+    /// `translate_fs_4` (scalar path): phases `[-1, -hbc, +1, +hbc]`
+    /// per 4 samples. C's `i < len / 4` loop simply skips a partial
+    /// tail (no overrun here, unlike the int16 twin) — `chunks_exact`
+    /// reproduces that.
+    fn translate_fs_4(&mut self, samples: &mut [f32]) {
+        let hbc = self.hbc;
+        for chunk in samples.chunks_exact_mut(4) {
+            chunk[0] = -chunk[0];
+            chunk[1] = -chunk[1] * hbc;
+            // chunk[2] unchanged
+            chunk[3] *= hbc;
+        }
+        self.fir_interleaved(samples);
+        self.delay_interleaved(samples);
+    }
+
+    /// `iqconverter_float_process`: in-place conversion (interleaved
+    /// I/Q output, like the int16 twin).
+    pub(crate) fn process(&mut self, samples: &mut [f32]) {
+        self.remove_dc(samples);
+        self.translate_fs_4(samples);
+    }
+}
+
+/// Compile-time tie between the stock kernel length and the `len = 24`
+/// FIR specialization the module docs promise.
+const _: () = assert!(HB_KERNEL_FLOAT_LEN / 2 + 1 == 24);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::filters::HB_KERNEL_FLOAT;
+    use crate::test_vectors::{SCENARIOS, load_scenario};
+
+    /// `(word - 2048) * SAMPLE_SCALE` — the consumer's float input
+    /// conversion, mirroring the harness.
+    #[allow(clippy::cast_precision_loss)]
+    fn to_f32(words: &[u16]) -> Vec<f32> {
+        words
+            .iter()
+            .map(|&w| (i32::from(w) - 2048) as f32 * (1.0 / 2048.0))
+            .collect()
+    }
+
+    #[test]
+    fn matches_c_golden_vectors_bit_for_bit() {
+        for name in SCENARIOS {
+            let v = load_scenario(name);
+            assert_eq!(v.input.len(), v.float.len(), "{name}: fixture lengths");
+            assert_eq!(v.input.len() % 2048, 0, "{name}: block alignment");
+            let mut cnv = IqConverterFloat::new(&HB_KERNEL_FLOAT);
+            let mut samples = to_f32(&v.input);
+            for (bi, (block, expected)) in samples
+                .chunks_mut(2048)
+                .zip(v.float.chunks(2048))
+                .enumerate()
+            {
+                cnv.process(block);
+                for (i, (got, want)) in block.iter().zip(expected.iter()).enumerate() {
+                    assert!(
+                        got.to_bits() == want.to_bits(),
+                        "{name} block {bi} sample {i}: got {got:e} ({:#010x}) want {want:e} ({:#010x})",
+                        got.to_bits(),
+                        want.to_bits()
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn reset_restores_fresh_converter_behavior() {
+        let v = load_scenario("noise");
+        let mut a = to_f32(&v.input[..2048]);
+        let mut b = a.clone();
+        let mut cnv = IqConverterFloat::new(&HB_KERNEL_FLOAT);
+        cnv.process(&mut a);
+        let mut scratch = to_f32(&v.input[2048..4096]);
+        cnv.process(&mut scratch);
+        cnv.reset();
+        cnv.process(&mut b);
+        assert_eq!(
+            a.iter().map(|f| f.to_bits()).collect::<Vec<_>>(),
+            b.iter().map(|f| f.to_bits()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn kernel_shape_and_center_tap() {
+        let cnv = IqConverterFloat::new(&HB_KERNEL_FLOAT);
+        assert_eq!(cnv.fir_kernel.len(), 24);
+        assert_eq!(cnv.delay_line.len(), 12);
+        assert!((cnv.hbc - 0.5).abs() < f32::EPSILON, "hbc = center tap");
+    }
+}

--- a/crates/libairspy/src/lib.rs
+++ b/crates/libairspy/src/lib.rs
@@ -18,6 +18,7 @@ pub mod conversion;
 pub mod device;
 pub mod error;
 mod filters;
+mod iqconverter_float;
 mod iqconverter_int16;
 pub mod reader;
 pub mod stream;

--- a/crates/libairspy/src/stream.rs
+++ b/crates/libairspy/src/stream.rs
@@ -301,16 +301,6 @@ fn run_reader(shared: &StreamShared, handle: &rusb::DeviceHandle<rusb::Context>)
     shared.queue.shutdown();
 }
 
-/// The sample types `start_rx` accepts today. `Float32Iq` returns
-/// [`Error::Unsupported`] until its converter port lands (the last
-/// M3 gate).
-fn validate_stream_sample_type(sample_type: SampleType) -> Result<()> {
-    if matches!(sample_type, SampleType::Float32Iq) {
-        return Err(Error::Unsupported);
-    }
-    Ok(())
-}
-
 /// Worker-thread handles held by a streaming [`Device`].
 pub(crate) struct StreamWorkers {
     pub(crate) shared: Arc<StreamShared>,
@@ -335,8 +325,7 @@ impl Device {
     /// consumer threads. Returns [`Error::Busy`] while streaming.
     ///
     /// The sample type and packing mode are latched here (see
-    /// [`Device::set_sample_type`]). `Float32Iq` returns
-    /// [`Error::Unsupported`] until its converter port lands.
+    /// [`Device::set_sample_type`]); every sample type is supported.
     ///
     /// The callback runs on the consumer thread; return `true` to
     /// keep streaming, `false` to stop (C's nonzero-return stop).
@@ -345,7 +334,6 @@ impl Device {
         callback: impl FnMut(Transfer<'_>) -> bool + Send + 'static,
     ) -> Result<()> {
         let sample_type = self.sample_type();
-        validate_stream_sample_type(sample_type)?;
         let packing_enabled = self.packing_enabled;
         self.reap_finished_workers()?;
         // Converter resets and drop-counter zeroing from
@@ -558,23 +546,6 @@ mod tests {
         std::thread::sleep(core::time::Duration::from_millis(50));
         q.shutdown();
         assert!(waiter.join().expect("join").is_none());
-    }
-
-    #[test]
-    fn start_rx_gate_rejects_float_iq_until_dsp_lands() {
-        assert!(matches!(
-            validate_stream_sample_type(SampleType::Float32Iq),
-            Err(crate::Error::Unsupported)
-        ));
-        for t in [
-            SampleType::Int16Iq,
-            SampleType::Float32Real,
-            SampleType::Int16Real,
-            SampleType::Uint16Real,
-            SampleType::Raw,
-        ] {
-            assert!(validate_stream_sample_type(t).is_ok(), "{t:?} must pass");
-        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #18 — the last M3 converter; every `airspy_sample_type` is now supported end-to-end.

**Port fidelity** (`iqconverter_float.rs`, from the all-MIT `bd15be38` reference):
- The reference builds on Linux/GCC compile the **scalar** paths (neither `USE_SSE2` nor `FIR_STANDARD` is defined there), and the stock 47-tap kernel gives `len = 24`, so C dispatches to `fir_interleaved_24` — the symmetric-pair summation (`Σ k[i]·(q[i]+q[n-1-i])`, left-associated) this port reproduces term-for-term. Result: **bit-exact** against the float golden vectors across all four scenarios × three sequential blocks — no tolerance needed (the harness's `gcc -O2` didn't contract the chains).
- `process_fir_taps`' exact 8/4/2-block grouping is transcribed for custom kernel lengths outside the 4/8/12/24 specializations (the C dead-code odd-tap branch stays dead); the dispatch mirrors C's switch.
- `HB_KERNEL_FLOAT` transcribed with C's exact conversion semantics: the upstream initializers are unsuffixed *double* literals narrowed to float, so the Rust table uses `f64 → f32` casts rather than direct f32 literals (double-rounding parity).
- `translate_fs_4`'s partial-tail skip is C behavior here (its `len / 4` loop simply stops — no overrun in the float twin), and the float `reset` is correct upstream, transcribed as-is.

**Pipeline**: `Float32Iq` flows through `convert_block` (float convert → iqconvert → halved count, whole-IQ-pairs delivery like the int16 twin); the `start_rx` sample-type gate is deleted — all six types accepted.

TDD: float vector tests written first and watched fail; bit-exact assertions with hex bit patterns in failure messages; reset-restores-fresh, kernel-shape/center-tap pins, dispatch golden-vector + pairs-truncation tests. 84 tests green, workspace clippy `-D warnings` all features, fmt clean, tokio/smol combos green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Float32 IQ sample processing.
  * Float32 IQ data now receives conversion, filtering, and DC-removal processing.
  * Streaming now accepts Float32 IQ samples alongside existing sample types.

* **Bug Fixes**
  * Incomplete IQ pairs are safely truncated instead of being delivered partially.
  * Float32 conversion maintains processing state across blocks for consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->