### PR TITLE
M4: set_freq

### DIFF
--- a/crates/libairspy/src/board.rs
+++ b/crates/libairspy/src/board.rs
@@ -68,7 +68,10 @@ impl Device {
         let n = self.vendor_in(Command::BoardIdRead, 0, 0, &mut value)?;
         if n < 1 {
             // C: result < 1 → AIRSPY_ERROR_LIBUSB.
-            return Err(Error::Usb(rusb::Error::Other));
+            return Err(Error::ShortTransfer {
+                expected: 1,
+                actual: n,
+            });
         }
         Ok(value[0])
     }
@@ -93,7 +96,10 @@ impl Device {
         let n = self.vendor_in(Command::BoardPartIdSerialNoRead, 0, 0, &mut raw)?;
         if n < PARTID_SERIALNO_LEN {
             // C: result < length → AIRSPY_ERROR_LIBUSB.
-            return Err(Error::Usb(rusb::Error::Other));
+            return Err(Error::ShortTransfer {
+                expected: PARTID_SERIALNO_LEN,
+                actual: n,
+            });
         }
         Ok(PartIdSerial::from_le_bytes(&raw))
     }

--- a/crates/libairspy/src/board.rs
+++ b/crates/libairspy/src/board.rs
@@ -66,10 +66,10 @@ impl Device {
     pub fn board_id(&self) -> Result<u8> {
         let mut value = [0u8; 1];
         let n = self.vendor_in(Command::BoardIdRead, 0, 0, &mut value)?;
-        if n < 1 {
+        if n < value.len() {
             // C: result < 1 → AIRSPY_ERROR_LIBUSB.
-            return Err(Error::ShortTransfer {
-                expected: 1,
+            return Err(Error::TransferLengthMismatch {
+                expected: value.len(),
                 actual: n,
             });
         }
@@ -96,7 +96,7 @@ impl Device {
         let n = self.vendor_in(Command::BoardPartIdSerialNoRead, 0, 0, &mut raw)?;
         if n < PARTID_SERIALNO_LEN {
             // C: result < length → AIRSPY_ERROR_LIBUSB.
-            return Err(Error::ShortTransfer {
+            return Err(Error::TransferLengthMismatch {
                 expected: PARTID_SERIALNO_LEN,
                 actual: n,
             });

--- a/crates/libairspy/src/control.rs
+++ b/crates/libairspy/src/control.rs
@@ -1,0 +1,34 @@
+//! Device control-surface setters, ported from `airspy.c`.
+
+use crate::commands::Command;
+use crate::device::Device;
+use crate::error::{Error, Result};
+
+impl Device {
+    /// Tune the receiver (`airspy_set_freq`): the target frequency in
+    /// Hz travels as a 4-byte little-endian payload (`set_freq_params_t`
+    /// with `TO_LE`, airspy.c).
+    ///
+    /// The C header documents 24 MHz – 1.75 GHz as the valid range but
+    /// the library does not enforce it, and neither does this port —
+    /// the firmware is the authority.
+    pub fn set_freq(&self, freq_hz: u32) -> Result<()> {
+        let payload = freq_hz.to_le_bytes();
+        let n = self.vendor_out(Command::SetFreq, 0, 0, &payload)?;
+        if n < payload.len() {
+            // C: result < length → AIRSPY_ERROR_LIBUSB.
+            return Err(Error::Usb(rusb::Error::Other));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn freq_payload_is_little_endian() {
+        // set_freq_params.freq_hz = TO_LE(freq_hz): 100 MHz on the
+        // wire is 00 E1 F5 05.
+        assert_eq!(100_000_000u32.to_le_bytes(), [0x00, 0xE1, 0xF5, 0x05]);
+    }
+}

--- a/crates/libairspy/src/control.rs
+++ b/crates/libairspy/src/control.rs
@@ -3,6 +3,7 @@
 use crate::commands::Command;
 use crate::device::Device;
 use crate::error::{Error, Result};
+use crate::transfer::{NO_WINDEX, NO_WVALUE};
 
 impl Device {
     /// Tune the receiver (`airspy_set_freq`): the target frequency in
@@ -14,10 +15,13 @@ impl Device {
     /// the firmware is the authority.
     pub fn set_freq(&self, freq_hz: u32) -> Result<()> {
         let payload = freq_hz.to_le_bytes();
-        let n = self.vendor_out(Command::SetFreq, 0, 0, &payload)?;
+        let n = self.vendor_out(Command::SetFreq, NO_WVALUE, NO_WINDEX, &payload)?;
         if n < payload.len() {
             // C: result < length → AIRSPY_ERROR_LIBUSB.
-            return Err(Error::Usb(rusb::Error::Other));
+            return Err(Error::ShortTransfer {
+                expected: payload.len(),
+                actual: n,
+            });
         }
         Ok(())
     }

--- a/crates/libairspy/src/control.rs
+++ b/crates/libairspy/src/control.rs
@@ -18,7 +18,7 @@ impl Device {
         let n = self.vendor_out(Command::SetFreq, NO_WVALUE, NO_WINDEX, &payload)?;
         if n < payload.len() {
             // C: result < length → AIRSPY_ERROR_LIBUSB.
-            return Err(Error::ShortTransfer {
+            return Err(Error::TransferLengthMismatch {
                 expected: payload.len(),
                 actual: n,
             });

--- a/crates/libairspy/src/error.rs
+++ b/crates/libairspy/src/error.rs
@@ -31,12 +31,16 @@ pub enum Error {
     /// `AIRSPY_ERROR_LIBUSB` (-1000), carrying the underlying USB error.
     #[error("AIRSPY_ERROR_LIBUSB (-1000): {0}")]
     Usb(#[from] rusb::Error),
-    /// A control transfer moved fewer bytes than the request required.
-    /// C folds this into `AIRSPY_ERROR_LIBUSB` (its `result < length`
-    /// checks); the port keeps the C code/name for reporting parity
-    /// while preserving the byte counts (more-correct deviation).
-    #[error("AIRSPY_ERROR_LIBUSB (-1000): short transfer, {actual} of {expected} bytes")]
-    ShortTransfer {
+    /// A control transfer moved a different byte count than the
+    /// request required — usually short, but C's `result != 0` check
+    /// on empty requests also lands here with `actual > expected`.
+    /// C folds all of these into `AIRSPY_ERROR_LIBUSB`; the port keeps
+    /// that code/name for reporting parity while preserving the byte
+    /// counts (more-correct deviation).
+    #[error(
+        "AIRSPY_ERROR_LIBUSB (-1000): transfer length mismatch, {actual} bytes (expected {expected})"
+    )]
+    TransferLengthMismatch {
         /// Bytes the request required.
         expected: usize,
         /// Bytes actually transferred.
@@ -66,7 +70,7 @@ impl Error {
             Self::Busy => -6,
             Self::NoMem => -11,
             Self::Unsupported => -12,
-            Self::Usb(_) | Self::ShortTransfer { .. } => -1000,
+            Self::Usb(_) | Self::TransferLengthMismatch { .. } => -1000,
             Self::Thread => -1001,
             Self::StreamingThread => -1002,
             Self::StreamingStopped => -1003,
@@ -86,7 +90,7 @@ impl Error {
             // airspy_error_name(), so C returns its default string; we
             // replicate that for output parity with the C tools.
             Self::Unsupported => "airspy unknown error",
-            Self::Usb(_) | Self::ShortTransfer { .. } => "AIRSPY_ERROR_LIBUSB",
+            Self::Usb(_) | Self::TransferLengthMismatch { .. } => "AIRSPY_ERROR_LIBUSB",
             Self::Thread => "AIRSPY_ERROR_THREAD",
             Self::StreamingThread => "AIRSPY_ERROR_STREAMING_THREAD_ERR",
             Self::StreamingStopped => "AIRSPY_ERROR_STREAMING_STOPPED",
@@ -140,11 +144,11 @@ mod tests {
     }
 
     #[test]
-    fn short_transfer_reports_like_c_libusb_error() {
-        // Rust-side precision, C-compatible reporting: a short
-        // transfer is AIRSPY_ERROR_LIBUSB (-1000) to anything reading
+    fn transfer_length_mismatch_reports_like_c_libusb_error() {
+        // Rust-side precision, C-compatible reporting: a length
+        // mismatch is AIRSPY_ERROR_LIBUSB (-1000) to anything reading
         // codes/names, while the variant carries the byte counts.
-        let err = Error::ShortTransfer {
+        let err = Error::TransferLengthMismatch {
             expected: 4,
             actual: 1,
         };

--- a/crates/libairspy/src/error.rs
+++ b/crates/libairspy/src/error.rs
@@ -31,6 +31,17 @@ pub enum Error {
     /// `AIRSPY_ERROR_LIBUSB` (-1000), carrying the underlying USB error.
     #[error("AIRSPY_ERROR_LIBUSB (-1000): {0}")]
     Usb(#[from] rusb::Error),
+    /// A control transfer moved fewer bytes than the request required.
+    /// C folds this into `AIRSPY_ERROR_LIBUSB` (its `result < length`
+    /// checks); the port keeps the C code/name for reporting parity
+    /// while preserving the byte counts (more-correct deviation).
+    #[error("AIRSPY_ERROR_LIBUSB (-1000): short transfer, {actual} of {expected} bytes")]
+    ShortTransfer {
+        /// Bytes the request required.
+        expected: usize,
+        /// Bytes actually transferred.
+        actual: usize,
+    },
     /// `AIRSPY_ERROR_THREAD` (-1001)
     #[error("AIRSPY_ERROR_THREAD (-1001): worker thread failure")]
     Thread,
@@ -55,7 +66,7 @@ impl Error {
             Self::Busy => -6,
             Self::NoMem => -11,
             Self::Unsupported => -12,
-            Self::Usb(_) => -1000,
+            Self::Usb(_) | Self::ShortTransfer { .. } => -1000,
             Self::Thread => -1001,
             Self::StreamingThread => -1002,
             Self::StreamingStopped => -1003,
@@ -75,7 +86,7 @@ impl Error {
             // airspy_error_name(), so C returns its default string; we
             // replicate that for output parity with the C tools.
             Self::Unsupported => "airspy unknown error",
-            Self::Usb(_) => "AIRSPY_ERROR_LIBUSB",
+            Self::Usb(_) | Self::ShortTransfer { .. } => "AIRSPY_ERROR_LIBUSB",
             Self::Thread => "AIRSPY_ERROR_THREAD",
             Self::StreamingThread => "AIRSPY_ERROR_STREAMING_THREAD_ERR",
             Self::StreamingStopped => "AIRSPY_ERROR_STREAMING_STOPPED",
@@ -126,6 +137,21 @@ mod tests {
             "AIRSPY_ERROR_STREAMING_STOPPED"
         );
         assert_eq!(Error::Other.name(), "AIRSPY_ERROR_OTHER");
+    }
+
+    #[test]
+    fn short_transfer_reports_like_c_libusb_error() {
+        // Rust-side precision, C-compatible reporting: a short
+        // transfer is AIRSPY_ERROR_LIBUSB (-1000) to anything reading
+        // codes/names, while the variant carries the byte counts.
+        let err = Error::ShortTransfer {
+            expected: 4,
+            actual: 1,
+        };
+        assert_eq!(err.code(), -1000);
+        assert_eq!(err.name(), "AIRSPY_ERROR_LIBUSB");
+        let msg = err.to_string();
+        assert!(msg.contains('4') && msg.contains('1'), "got: {msg}");
     }
 
     #[test]

--- a/crates/libairspy/src/lib.rs
+++ b/crates/libairspy/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod board;
 pub mod commands;
+mod control;
 pub mod conversion;
 pub mod device;
 pub mod error;

--- a/crates/libairspy/src/stream.rs
+++ b/crates/libairspy/src/stream.rs
@@ -312,12 +312,14 @@ impl Device {
     /// `airspy_set_receiver_mode`: `AIRSPY_RECEIVER_MODE` with the
     /// mode in wValue.
     fn set_receiver_mode(&self, mode: ReceiverMode) -> Result<()> {
-        let n = self.vendor_out(Command::ReceiverMode, mode as u16, 0, &[])?;
-        if n != 0 {
+        // airspy_set_receiver_mode sends no payload (NULL, 0).
+        let payload: [u8; 0] = [];
+        let n = self.vendor_out(Command::ReceiverMode, mode as u16, 0, &payload)?;
+        if n != payload.len() {
             // C: result != 0 → AIRSPY_ERROR_LIBUSB (an empty request
             // that reports transferred bytes is a protocol mismatch).
-            return Err(Error::ShortTransfer {
-                expected: 0,
+            return Err(Error::TransferLengthMismatch {
+                expected: payload.len(),
                 actual: n,
             });
         }

--- a/crates/libairspy/src/stream.rs
+++ b/crates/libairspy/src/stream.rs
@@ -314,8 +314,12 @@ impl Device {
     fn set_receiver_mode(&self, mode: ReceiverMode) -> Result<()> {
         let n = self.vendor_out(Command::ReceiverMode, mode as u16, 0, &[])?;
         if n != 0 {
-            // C: result != 0 → AIRSPY_ERROR_LIBUSB.
-            return Err(Error::Usb(rusb::Error::Other));
+            // C: result != 0 → AIRSPY_ERROR_LIBUSB (an empty request
+            // that reports transferred bytes is a protocol mismatch).
+            return Err(Error::ShortTransfer {
+                expected: 0,
+                actual: n,
+            });
         }
         Ok(())
     }

--- a/crates/libairspy/src/stream.rs
+++ b/crates/libairspy/src/stream.rs
@@ -25,6 +25,7 @@ use crate::commands::{Command, ReceiverMode, SampleType};
 use crate::conversion::{Samples, Scratch, convert_block};
 use crate::device::Device;
 use crate::error::{Error, Result};
+use crate::transfer::NO_WINDEX;
 
 /// `RAW_BUFFER_COUNT` in airspy.c — slots in the received-samples ring.
 pub(crate) const RAW_BUFFER_COUNT: usize = 8;
@@ -314,7 +315,7 @@ impl Device {
     fn set_receiver_mode(&self, mode: ReceiverMode) -> Result<()> {
         // airspy_set_receiver_mode sends no payload (NULL, 0).
         let payload: [u8; 0] = [];
-        let n = self.vendor_out(Command::ReceiverMode, mode as u16, 0, &payload)?;
+        let n = self.vendor_out(Command::ReceiverMode, mode as u16, NO_WINDEX, &payload)?;
         if n != payload.len() {
             // C: result != 0 → AIRSPY_ERROR_LIBUSB (an empty request
             // that reports transferred bytes is a protocol mismatch).

--- a/crates/libairspy/src/transfer.rs
+++ b/crates/libairspy/src/transfer.rs
@@ -21,9 +21,14 @@ pub(crate) const CTRL_TIMEOUT: Duration = Duration::from_millis(500);
 /// LIBUSB_RECIPIENT_DEVICE` — the bmRequestType of every host-to-device
 /// request in airspy.c (0x00 | 0x40 | 0x00) — see e.g.
 /// `airspy_si5351c_write`'s `libusb_control_transfer` call.
-// First consumers are the receiver-mode/setter paths (M2/M4).
-#[allow(dead_code)]
 pub(crate) const VENDOR_OUT_REQUEST_TYPE: u8 = 0x40;
+
+/// Zero `wValue` for requests that carry no value parameter — the
+/// literal `0` argument the corresponding C calls pass.
+pub(crate) const NO_WVALUE: u16 = 0;
+/// Zero `wIndex` for requests that carry no index parameter — the
+/// literal `0` argument the corresponding C calls pass.
+pub(crate) const NO_WINDEX: u16 = 0;
 
 /// `LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR |
 /// LIBUSB_RECIPIENT_DEVICE` — the bmRequestType of every device-to-host
@@ -34,8 +39,6 @@ impl Device {
     /// Host-to-device vendor request. Returns the number of bytes
     /// transferred; rusb/libusb errors map to `Error::Usb` (C's
     /// `AIRSPY_ERROR_LIBUSB`).
-    // First consumers are the receiver-mode/setter paths (M2/M4).
-    #[allow(dead_code)]
     pub(crate) fn vendor_out(
         &self,
         command: Command,

--- a/crates/libairspy/src/transfer.rs
+++ b/crates/libairspy/src/transfer.rs
@@ -24,10 +24,11 @@ pub(crate) const CTRL_TIMEOUT: Duration = Duration::from_millis(500);
 pub(crate) const VENDOR_OUT_REQUEST_TYPE: u8 = 0x40;
 
 /// Zero `wValue` for requests that carry no value parameter — the
-/// literal `0` argument the corresponding C calls pass.
+/// literal `0` wValue argument in e.g. `airspy_set_freq`'s
+/// `libusb_control_transfer` call (airspy.c).
 pub(crate) const NO_WVALUE: u16 = 0;
 /// Zero `wIndex` for requests that carry no index parameter — the
-/// literal `0` argument the corresponding C calls pass.
+/// literal `0` wIndex argument in the same C calls.
 pub(crate) const NO_WINDEX: u16 = 0;
 
 /// `LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR |


### PR DESCRIPTION
Closes #19 — first M4 setter, deliberately small.

- `Device::set_freq(freq_hz)`: `airspy_set_freq` transcribed — the frequency travels as `set_freq_params_t`'s 4-byte little-endian payload (`TO_LE`) on `AIRSPY_SET_FREQ` with zero wValue/wIndex, and short transfers map to the libusb error exactly like C's `result < length` check.
- The C header documents 24 MHz–1.75 GHz but the library never enforces it; this port matches (documented — the firmware is the authority).
- New `control.rs` module hosts the M4 control surface as it grows.

Test pins the wire byte order (100 MHz → `00 E1 F5 05`). 85 tests green, workspace clippy `-D warnings` all features, fmt clean.

Heads-up for the queue: the remaining M4 setters (#20–#22) are similar-sized siblings — say the word if you'd like them batched like the async adapters were, otherwise they'll come one at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for setting the device’s operating frequency in hertz.
  - Reports when the device does not accept the complete frequency update.

- **Bug Fixes**
  - Improved error reporting for incomplete device data transfers.
  - Receiver mode changes now clearly identify unexpected transfer results.
  - Transfer errors include the expected and actual byte counts.

- **Tests**
  - Added coverage for frequency encoding and incomplete transfer handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->