### PR TITLE
M4: samplerate, gain/AGC, bias-T, packing setters

### DIFF
--- a/crates/libairspy/src/control.rs
+++ b/crates/libairspy/src/control.rs
@@ -48,10 +48,22 @@ impl Device {
     /// the library does not enforce it, and neither does this port —
     /// the firmware is the authority.
     pub fn set_freq(&self, freq_hz: u32) -> Result<()> {
-        let payload = freq_hz.to_le_bytes();
-        let n = self.vendor_out(Command::SetFreq, NO_WVALUE, NO_WINDEX, &payload)?;
-        if n < payload.len() {
-            // C: result < length → AIRSPY_ERROR_LIBUSB.
+        self.out_setter(
+            Command::SetFreq,
+            NO_WVALUE,
+            NO_WINDEX,
+            &freq_hz.to_le_bytes(),
+        )
+    }
+}
+
+impl Device {
+    /// The OUT pattern shared by `set_freq` and the GPIO writes: send
+    /// the payload and require the exact transferred length (C's
+    /// `result != length` checks).
+    fn out_setter(&self, command: Command, value: u16, index: u16, payload: &[u8]) -> Result<()> {
+        let n = self.vendor_out(command, value, index, payload)?;
+        if n != payload.len() {
             return Err(Error::TransferLengthMismatch {
                 expected: payload.len(),
                 actual: n,
@@ -59,9 +71,7 @@ impl Device {
         }
         Ok(())
     }
-}
 
-impl Device {
     /// The IN-with-status pattern most C setters share: a 1-byte read
     /// with the value in `wIndex`, `result < 1` mapping to the libusb
     /// error.
@@ -78,10 +88,16 @@ impl Device {
     }
 
     /// Select the sample rate (`airspy_set_samplerate`): the argument
-    /// is either an index into [`Device::samplerates`]'s table or a
-    /// literal rate in Hz (at or above `MIN_SAMPLERATE_BY_VALUE`).
-    /// Off-table literal rates are sent in kHz, doubled first for IQ
-    /// sample types, exactly as C computes them.
+    /// is either a table index or a literal rate in Hz (at or above
+    /// `MIN_SAMPLERATE_BY_VALUE`).
+    ///
+    /// Like C, literal rates match against the **undoubled firmware
+    /// table** — for non-IQ sample types [`Device::samplerates`]
+    /// reports doubled values, and passing one of those doubled rates
+    /// takes the off-table kHz path rather than matching an index
+    /// (faithful to `airspy_set_samplerate`). Off-table rates are
+    /// doubled for IQ types and sent in kHz, exactly as C computes
+    /// them.
     pub fn set_samplerate(&self, samplerate: u32) -> Result<()> {
         let mut value = samplerate;
         if value >= MIN_SAMPLERATE_BY_VALUE {
@@ -180,15 +196,7 @@ impl Device {
     /// surface lands.
     pub(crate) fn gpio_write(&self, port: GpioPort, pin: GpioPin, value: u8) -> Result<()> {
         let port_pin = u16::from((port as u8) << 5 | pin as u8);
-        let payload: [u8; 0] = [];
-        let n = self.vendor_out(Command::GpioWrite, u16::from(value), port_pin, &payload)?;
-        if n != payload.len() {
-            return Err(Error::TransferLengthMismatch {
-                expected: payload.len(),
-                actual: n,
-            });
-        }
-        Ok(())
+        self.out_setter(Command::GpioWrite, u16::from(value), port_pin, &[])
     }
 
     /// Toggle the bias tee (`airspy_set_rf_bias` — a GPIO write to
@@ -455,6 +463,34 @@ mod tests {
         // port 1 << 5 | pin 13 = 45.
         assert_eq!(c.index, 45);
         assert!(c.data.is_empty());
+    }
+
+    #[test]
+    fn set_packing_busy_while_streaming() {
+        use crate::transport::mock::BulkRead;
+        let (transport, mut device) = mock_device();
+        transport.script_bulk(vec![BulkRead::Fill(0)]);
+        device
+            .set_sample_type(crate::commands::SampleType::Raw)
+            .expect("type");
+        device.start_rx(|_| true).expect("start");
+        assert!(matches!(device.set_packing(true), Err(crate::Error::Busy)));
+        device.stop_rx().expect("stop");
+        assert!(!device.packing_enabled, "flag untouched on Busy");
+    }
+
+    #[test]
+    fn in_setter_zero_length_status_maps_to_length_mismatch() {
+        let (transport, device) = mock_device();
+        transport.script_reads(vec![Ok(vec![])]); // 0 of 1 status byte
+        let err = device.set_lna_gain(1).expect_err("short status");
+        assert!(matches!(
+            err,
+            crate::Error::TransferLengthMismatch {
+                expected: 1,
+                actual: 0
+            }
+        ));
     }
 
     #[test]

--- a/crates/libairspy/src/control.rs
+++ b/crates/libairspy/src/control.rs
@@ -1,9 +1,43 @@
 //! Device control-surface setters, ported from `airspy.c`.
 
-use crate::commands::Command;
+use crate::commands::{Command, GpioPin, GpioPort, SampleType};
 use crate::device::Device;
 use crate::error::{Error, Result};
+use crate::stream::BULK_ENDPOINT;
 use crate::transfer::{NO_WINDEX, NO_WVALUE};
+
+/// `MIN_SAMPLERATE_BY_VALUE` (airspy.c) — arguments at or above this
+/// are literal rates in Hz; below it they are table indices.
+const MIN_SAMPLERATE_BY_VALUE: u32 = 1_000_000;
+
+/// `GAIN_COUNT` (airspy.c) — entries in each composite-gain table.
+const GAIN_COUNT: usize = 22;
+
+// The composite-gain tables from airspy.c (BSD-3-Clause), transcribed
+// verbatim: airspy_linearity_*_gains / airspy_sensitivity_*_gains.
+#[rustfmt::skip]
+const LINEARITY_VGA_GAINS: [u8; GAIN_COUNT] =
+    [13, 12, 11, 11, 11, 11, 11, 10, 10, 10, 10, 10, 10, 10, 10, 10, 9, 8, 7, 6, 5, 4];
+#[rustfmt::skip]
+const LINEARITY_MIXER_GAINS: [u8; GAIN_COUNT] =
+    [12, 12, 11, 9, 8, 7, 6, 6, 5, 0, 0, 1, 0, 0, 2, 2, 1, 1, 1, 1, 0, 0];
+#[rustfmt::skip]
+const LINEARITY_LNA_GAINS: [u8; GAIN_COUNT] =
+    [14, 14, 14, 13, 12, 10, 9, 9, 8, 9, 8, 6, 5, 3, 1, 0, 0, 0, 0, 0, 0, 0];
+#[rustfmt::skip]
+const SENSITIVITY_VGA_GAINS: [u8; GAIN_COUNT] =
+    [13, 12, 11, 10, 9, 8, 7, 6, 5, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4, 4];
+#[rustfmt::skip]
+const SENSITIVITY_MIXER_GAINS: [u8; GAIN_COUNT] =
+    [12, 12, 12, 12, 11, 10, 10, 9, 9, 8, 7, 4, 4, 4, 3, 2, 2, 1, 0, 0, 0, 0];
+#[rustfmt::skip]
+const SENSITIVITY_LNA_GAINS: [u8; GAIN_COUNT] =
+    [14, 14, 14, 14, 14, 14, 14, 14, 14, 13, 12, 12, 9, 9, 8, 7, 6, 5, 3, 2, 1, 0];
+
+/// `airspy_set_lna_gain`'s clamp bound.
+const LNA_GAIN_MAX: u8 = 14;
+/// `airspy_set_mixer_gain` / `airspy_set_vga_gain`'s clamp bound.
+const MIXER_VGA_GAIN_MAX: u8 = 15;
 
 impl Device {
     /// Tune the receiver (`airspy_set_freq`): the target frequency in
@@ -23,6 +57,158 @@ impl Device {
                 actual: n,
             });
         }
+        Ok(())
+    }
+}
+
+impl Device {
+    /// The IN-with-status pattern most C setters share: a 1-byte read
+    /// with the value in `wIndex`, `result < 1` mapping to the libusb
+    /// error.
+    fn in_setter(&self, command: Command, index: u16) -> Result<()> {
+        let mut status = [0u8; 1];
+        let n = self.vendor_in(command, NO_WVALUE, index, &mut status)?;
+        if n < status.len() {
+            return Err(Error::TransferLengthMismatch {
+                expected: status.len(),
+                actual: n,
+            });
+        }
+        Ok(())
+    }
+
+    /// Select the sample rate (`airspy_set_samplerate`): the argument
+    /// is either an index into [`Device::samplerates`]'s table or a
+    /// literal rate in Hz (at or above `MIN_SAMPLERATE_BY_VALUE`).
+    /// Off-table literal rates are sent in kHz, doubled first for IQ
+    /// sample types, exactly as C computes them.
+    pub fn set_samplerate(&self, samplerate: u32) -> Result<()> {
+        let mut value = samplerate;
+        if value >= MIN_SAMPLERATE_BY_VALUE {
+            if let Some(i) = self.raw_samplerates().iter().position(|&r| r == value) {
+                value = u32::try_from(i).unwrap_or(u32::MAX);
+            } else {
+                if matches!(
+                    self.sample_type(),
+                    SampleType::Float32Iq | SampleType::Int16Iq
+                ) {
+                    value = value.wrapping_mul(2);
+                }
+                value /= 1000;
+            }
+        }
+        // C clears the bulk endpoint halt before the request and
+        // ignores the result.
+        let _ = self.usb_handle().clear_halt(BULK_ENDPOINT);
+        // C passes the u32 into libusb's u16 wIndex — same truncation.
+        #[allow(clippy::cast_possible_truncation)]
+        self.in_setter(Command::SetSamplerate, value as u16)
+    }
+
+    /// `airspy_set_lna_gain` (0–14; larger values clamp, like C).
+    pub fn set_lna_gain(&self, value: u8) -> Result<()> {
+        self.in_setter(Command::SetLnaGain, u16::from(value.min(LNA_GAIN_MAX)))
+    }
+
+    /// `airspy_set_mixer_gain` (0–15; larger values clamp, like C).
+    pub fn set_mixer_gain(&self, value: u8) -> Result<()> {
+        self.in_setter(
+            Command::SetMixerGain,
+            u16::from(value.min(MIXER_VGA_GAIN_MAX)),
+        )
+    }
+
+    /// `airspy_set_vga_gain` (0–15; larger values clamp, like C).
+    pub fn set_vga_gain(&self, value: u8) -> Result<()> {
+        self.in_setter(
+            Command::SetVgaGain,
+            u16::from(value.min(MIXER_VGA_GAIN_MAX)),
+        )
+    }
+
+    /// `airspy_set_lna_agc`.
+    pub fn set_lna_agc(&self, enabled: bool) -> Result<()> {
+        self.in_setter(Command::SetLnaAgc, u16::from(enabled))
+    }
+
+    /// `airspy_set_mixer_agc`.
+    pub fn set_mixer_agc(&self, enabled: bool) -> Result<()> {
+        self.in_setter(Command::SetMixerAgc, u16::from(enabled))
+    }
+
+    /// The shared composite-gain sequence of `airspy_set_linearity_gain`
+    /// and `airspy_set_sensitivity_gain`: clamp, reverse the index,
+    /// disable both AGCs, then write the three table gains.
+    fn set_composite_gain(
+        &self,
+        value: u8,
+        vga: &[u8; GAIN_COUNT],
+        mixer: &[u8; GAIN_COUNT],
+        lna: &[u8; GAIN_COUNT],
+    ) -> Result<()> {
+        let clamped = usize::from(value).min(GAIN_COUNT - 1);
+        let idx = GAIN_COUNT - 1 - clamped;
+        self.set_mixer_agc(false)?;
+        self.set_lna_agc(false)?;
+        self.set_vga_gain(vga[idx])?;
+        self.set_mixer_gain(mixer[idx])?;
+        self.set_lna_gain(lna[idx])
+    }
+
+    /// `airspy_set_linearity_gain` (0–21).
+    pub fn set_linearity_gain(&self, value: u8) -> Result<()> {
+        self.set_composite_gain(
+            value,
+            &LINEARITY_VGA_GAINS,
+            &LINEARITY_MIXER_GAINS,
+            &LINEARITY_LNA_GAINS,
+        )
+    }
+
+    /// `airspy_set_sensitivity_gain` (0–21).
+    pub fn set_sensitivity_gain(&self, value: u8) -> Result<()> {
+        self.set_composite_gain(
+            value,
+            &SENSITIVITY_VGA_GAINS,
+            &SENSITIVITY_MIXER_GAINS,
+            &SENSITIVITY_LNA_GAINS,
+        )
+    }
+
+    /// `airspy_gpio_write`: `wValue` carries the level, `wIndex`
+    /// packs `port << 5 | pin`. Crate-internal until the full GPIO
+    /// surface lands.
+    pub(crate) fn gpio_write(&self, port: GpioPort, pin: GpioPin, value: u8) -> Result<()> {
+        let port_pin = u16::from((port as u8) << 5 | pin as u8);
+        let payload: [u8; 0] = [];
+        let n = self.vendor_out(Command::GpioWrite, u16::from(value), port_pin, &payload)?;
+        if n != payload.len() {
+            return Err(Error::TransferLengthMismatch {
+                expected: payload.len(),
+                actual: n,
+            });
+        }
+        Ok(())
+    }
+
+    /// Toggle the bias tee (`airspy_set_rf_bias` — a GPIO write to
+    /// port 1 pin 13).
+    pub fn set_rf_bias(&self, enabled: bool) -> Result<()> {
+        self.gpio_write(GpioPort::Port1, GpioPin::Pin13, u8::from(enabled))
+    }
+
+    /// Toggle 12-bit packed transfers (`airspy_set_packing`). Refused
+    /// with [`Error::Busy`] while streaming, like C.
+    ///
+    /// Deviation: C cancels and reallocates its transfer buffers here;
+    /// this engine sizes its buffers per `start_rx`, so only the flag
+    /// changes.
+    pub fn set_packing(&mut self, enabled: bool) -> Result<()> {
+        if self.is_streaming() {
+            return Err(Error::Busy);
+        }
+        self.in_setter(Command::SetPacking, u16::from(enabled))?;
+        self.packing_enabled = enabled;
         Ok(())
     }
 }
@@ -155,5 +341,128 @@ mod tests {
         // against the independent wire transcription so production
         // drift is caught.
         assert_eq!(device.samplerates(), wire::FALLBACK_SAMPLERATES.to_vec());
+    }
+
+    /// The IN-with-status pattern most setters use: one `read_control`
+    /// with the value in wIndex and a 1-byte status buffer.
+    fn assert_in_setter(c: &crate::transport::mock::ControlCall, request: u8, index: u16) {
+        assert_eq!(c.request_type, wire::VENDOR_IN);
+        assert_eq!(c.request, request);
+        assert_eq!((c.value, c.index), (0, index));
+        assert_eq!(c.data.len(), 1);
+        assert_eq!(c.timeout, wire::CTRL_TIMEOUT);
+    }
+
+    #[test]
+    fn set_samplerate_by_index_matches_table() {
+        let (transport, device) = mock_device();
+        transport.script_reads(vec![Ok(vec![0u8])]);
+        // 2_500_000 is index 1 of the fallback table.
+        device.set_samplerate(2_500_000).expect("set");
+        let calls = transport.take_recorded();
+        assert_in_setter(&calls[0], wire::SET_SAMPLERATE, 1);
+    }
+
+    #[test]
+    fn set_samplerate_by_value_scales_for_iq() {
+        let (transport, mut device) = mock_device();
+        // Default type is Float32Iq: an off-table rate doubles then
+        // divides by 1000 (6 MHz -> 12000).
+        transport.script_reads(vec![Ok(vec![0u8])]);
+        device.set_samplerate(6_000_000).expect("set");
+        assert_in_setter(&transport.take_recorded()[0], wire::SET_SAMPLERATE, 12_000);
+
+        // A real (non-IQ) type skips the doubling (6 MHz -> 6000).
+        device
+            .set_sample_type(crate::commands::SampleType::Int16Real)
+            .expect("type");
+        transport.script_reads(vec![Ok(vec![0u8])]);
+        device.set_samplerate(6_000_000).expect("set");
+        assert_in_setter(&transport.take_recorded()[0], wire::SET_SAMPLERATE, 6_000);
+    }
+
+    #[test]
+    fn set_samplerate_small_values_are_raw_indices() {
+        let (transport, device) = mock_device();
+        transport.script_reads(vec![Ok(vec![0u8])]);
+        device.set_samplerate(0).expect("set");
+        assert_in_setter(&transport.take_recorded()[0], wire::SET_SAMPLERATE, 0);
+    }
+
+    #[test]
+    fn gain_setters_clamp_like_c() {
+        let (transport, device) = mock_device();
+        // LNA clamps to 14; mixer and VGA clamp to 15.
+        transport.script_reads(vec![Ok(vec![0u8]); 3]);
+        device.set_lna_gain(200).expect("lna");
+        device.set_mixer_gain(200).expect("mixer");
+        device.set_vga_gain(200).expect("vga");
+        let calls = transport.take_recorded();
+        assert_in_setter(&calls[0], wire::SET_LNA_GAIN, 14);
+        assert_in_setter(&calls[1], wire::SET_MIXER_GAIN, 15);
+        assert_in_setter(&calls[2], wire::SET_VGA_GAIN, 15);
+    }
+
+    #[test]
+    fn agc_setters_send_bool_as_byte() {
+        let (transport, device) = mock_device();
+        transport.script_reads(vec![Ok(vec![0u8]); 2]);
+        device.set_lna_agc(true).expect("lna agc");
+        device.set_mixer_agc(false).expect("mixer agc");
+        let calls = transport.take_recorded();
+        assert_in_setter(&calls[0], wire::SET_LNA_AGC, 1);
+        assert_in_setter(&calls[1], wire::SET_MIXER_AGC, 0);
+    }
+
+    #[test]
+    fn linearity_gain_runs_c_sequence_with_table_values() {
+        let (transport, device) = mock_device();
+        transport.script_reads(vec![Ok(vec![0u8]); 5]);
+        // value 0 -> reversed index 21: vga 4, mixer 0, lna 0.
+        device.set_linearity_gain(0).expect("linearity");
+        let calls = transport.take_recorded();
+        assert_eq!(calls.len(), 5);
+        assert_in_setter(&calls[0], wire::SET_MIXER_AGC, 0);
+        assert_in_setter(&calls[1], wire::SET_LNA_AGC, 0);
+        assert_in_setter(&calls[2], wire::SET_VGA_GAIN, 4);
+        assert_in_setter(&calls[3], wire::SET_MIXER_GAIN, 0);
+        assert_in_setter(&calls[4], wire::SET_LNA_GAIN, 0);
+    }
+
+    #[test]
+    fn sensitivity_gain_clamps_and_uses_its_tables() {
+        let (transport, device) = mock_device();
+        transport.script_reads(vec![Ok(vec![0u8]); 5]);
+        // Any value >= 22 clamps to 21 -> reversed index 0:
+        // vga 13, mixer 12, lna 14.
+        device.set_sensitivity_gain(200).expect("sensitivity");
+        let calls = transport.take_recorded();
+        assert_in_setter(&calls[2], wire::SET_VGA_GAIN, 13);
+        assert_in_setter(&calls[3], wire::SET_MIXER_GAIN, 12);
+        assert_in_setter(&calls[4], wire::SET_LNA_GAIN, 14);
+    }
+
+    #[test]
+    fn rf_bias_writes_gpio_port1_pin13() {
+        let (transport, device) = mock_device();
+        device.set_rf_bias(true).expect("bias");
+        let calls = transport.take_recorded();
+        assert_eq!(calls.len(), 1);
+        let c = &calls[0];
+        assert_eq!(c.request_type, wire::VENDOR_OUT);
+        assert_eq!(c.request, wire::GPIO_WRITE);
+        assert_eq!(c.value, 1);
+        // port 1 << 5 | pin 13 = 45.
+        assert_eq!(c.index, 45);
+        assert!(c.data.is_empty());
+    }
+
+    #[test]
+    fn set_packing_updates_flag_and_wire() {
+        let (transport, mut device) = mock_device();
+        transport.script_reads(vec![Ok(vec![0u8])]);
+        device.set_packing(true).expect("packing");
+        assert!(device.packing_enabled);
+        assert_in_setter(&transport.take_recorded()[0], wire::SET_PACKING, 1);
     }
 }

--- a/crates/libairspy/src/device.rs
+++ b/crates/libairspy/src/device.rs
@@ -345,6 +345,12 @@ impl Device {
         self.sample_type
     }
 
+    /// The undoubled firmware rate table (the values
+    /// `airspy_set_samplerate` matches literal rates against).
+    pub(crate) fn raw_samplerates(&self) -> &[u32] {
+        &self.supported_samplerates
+    }
+
     /// Streaming worker accessors for `stream.rs`.
     pub(crate) fn stream_workers(&self) -> Option<&StreamWorkers> {
         self.workers.as_ref()

--- a/crates/libairspy/src/transport.rs
+++ b/crates/libairspy/src/transport.rs
@@ -109,6 +109,22 @@ pub(crate) mod mock {
         pub(crate) const BOARD_ID_READ: u8 = 9;
         /// `AIRSPY_GET_SAMPLERATES = 25` (`airspy_commands.h`).
         pub(crate) const GET_SAMPLERATES: u8 = 25;
+        /// `AIRSPY_SET_SAMPLERATE = 12` (`airspy_commands.h`).
+        pub(crate) const SET_SAMPLERATE: u8 = 12;
+        /// `AIRSPY_SET_LNA_GAIN = 14` (`airspy_commands.h`).
+        pub(crate) const SET_LNA_GAIN: u8 = 14;
+        /// `AIRSPY_SET_MIXER_GAIN = 15` (`airspy_commands.h`).
+        pub(crate) const SET_MIXER_GAIN: u8 = 15;
+        /// `AIRSPY_SET_VGA_GAIN = 16` (`airspy_commands.h`).
+        pub(crate) const SET_VGA_GAIN: u8 = 16;
+        /// `AIRSPY_SET_LNA_AGC = 17` (`airspy_commands.h`).
+        pub(crate) const SET_LNA_AGC: u8 = 17;
+        /// `AIRSPY_SET_MIXER_AGC = 18` (`airspy_commands.h`).
+        pub(crate) const SET_MIXER_AGC: u8 = 18;
+        /// `AIRSPY_GPIO_WRITE = 21` (`airspy_commands.h`).
+        pub(crate) const GPIO_WRITE: u8 = 21;
+        /// `AIRSPY_SET_PACKING = 26` (`airspy_commands.h`).
+        pub(crate) const SET_PACKING: u8 = 26;
         /// OUT|VENDOR|DEVICE (airspy.c's host-to-device transfers).
         pub(crate) const VENDOR_OUT: u8 = 0x40;
         /// IN|VENDOR|DEVICE (airspy.c's device-to-host transfers).


### PR DESCRIPTION
Closes #20, closes #21, closes #22 — combined per Jason, and the first PR fully built on the #60 seam: **every setter ships with transport-boundary tests**.

- **`set_samplerate`** (`airspy_set_samplerate`): literal rates (≥ 1 MHz) first match the raw firmware table → index; off-table rates double for IQ types then encode as kHz; C's u32→u16 wIndex truncation preserved; `clear_halt(0x81)` sent (result ignored) before the request. Notably these setters use **IN** transfers with a 1-byte status — the shared `in_setter` helper carries C's `result < 1` check.
- **Gains/AGC** (#21): LNA clamps at 14, mixer/VGA at 15 (C clamps rather than errors — documented); AGC toggles take `bool`. **Composite gains**: the verbatim `airspy_linearity_*`/`airspy_sensitivity_*` tables (22 entries each, BSD airspy.c), clamp → reversed index → mixer-AGC-off → LNA-AGC-off → VGA → mixer → LNA, exactly C's sequence.
- **Bias-T/packing** (#22): `set_rf_bias` is C's GPIO write to port 1 pin 13 (`gpio_write` lands crate-internal; the public GPIO surface is #24). `set_packing` keeps C's `Busy`-while-streaming gate; deviation: C reallocates its transfer buffers here, ours are sized per `start_rx`, so only the flag changes (documented).

**Boundary tests (10 new)**: samplerate by-index/by-value-IQ/by-value-real/raw-index paths, gain clamps on the wire, AGC bytes, the full 5-call linearity sequence with table values (and sensitivity's clamp + tables), rf_bias's exact GPIO encoding (`wValue 1, wIndex 45`), packing's flag + wire. New wire constants for all nine commands.

TDD: all tests written first and watched fail (14 missing-method errors). 106 tests green, workspace clippy `-D warnings` all features, fmt clean, tokio/smol combos green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added controls for sample rate, LNA, mixer, and VGA gain.
  - Added LNA and mixer AGC controls.
  - Added linearity and sensitivity gain settings.
  - Added RF-bias, GPIO, and packing-mode controls.

- **Bug Fixes**
  - Improved validation for streaming state, gain ranges, samplerates, and transfer lengths.
  - Added reliable handling of device status responses.

- **Tests**
  - Added comprehensive coverage for control behavior and device communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->