### PR TITLE
M4: peripheral registers, GPIO surface, SPI flash (#23, #24, #25)

### DIFF
--- a/crates/libairspy/src/control.rs
+++ b/crates/libairspy/src/control.rs
@@ -61,7 +61,13 @@ impl Device {
     /// The OUT pattern shared by `set_freq` and the GPIO writes: send
     /// the payload and require the exact transferred length (C's
     /// `result != length` checks).
-    fn out_setter(&self, command: Command, value: u16, index: u16, payload: &[u8]) -> Result<()> {
+    pub(crate) fn out_setter(
+        &self,
+        command: Command,
+        value: u16,
+        index: u16,
+        payload: &[u8],
+    ) -> Result<()> {
         let n = self.vendor_out(command, value, index, payload)?;
         if n != payload.len() {
             return Err(Error::TransferLengthMismatch {
@@ -191,10 +197,9 @@ impl Device {
         )
     }
 
-    /// `airspy_gpio_write`: `wValue` carries the level, `wIndex`
-    /// packs `port << 5 | pin`. Crate-internal until the full GPIO
-    /// surface lands.
-    pub(crate) fn gpio_write(&self, port: GpioPort, pin: GpioPin, value: u8) -> Result<()> {
+    /// Write a GPIO level (`airspy_gpio_write`): `wValue` carries the
+    /// level (0 or 1), `wIndex` packs `port << 5 | pin`.
+    pub fn gpio_write(&self, port: GpioPort, pin: GpioPin, value: u8) -> Result<()> {
         let port_pin = u16::from((port as u8) << 5 | pin as u8);
         self.out_setter(Command::GpioWrite, u16::from(value), port_pin, &[])
     }
@@ -222,7 +227,7 @@ impl Device {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::sync::Arc;
 
     use crate::device::Device;

--- a/crates/libairspy/src/lib.rs
+++ b/crates/libairspy/src/lib.rs
@@ -21,6 +21,7 @@ pub mod error;
 mod filters;
 mod iqconverter_float;
 mod iqconverter_int16;
+mod peripherals;
 pub mod reader;
 pub mod stream;
 #[cfg(feature = "smol")]

--- a/crates/libairspy/src/peripherals.rs
+++ b/crates/libairspy/src/peripherals.rs
@@ -235,6 +235,7 @@ mod tests {
             0
         );
         let calls = transport.take_recorded();
+        assert_eq!(calls.len(), 4);
         // port 2 << 5 | pin 7 = 71; port 0 << 5 | pin 31 = 31.
         assert_eq!(calls[0].request, wire::GPIO_WRITE);
         assert_eq!((calls[0].value, calls[0].index), (1, 71));
@@ -252,6 +253,7 @@ mod tests {
         device.spiflash_erase().expect("erase");
         device.spiflash_erase_sector(5).expect("sector");
         let calls = transport.take_recorded();
+        assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].request, wire::SPIFLASH_ERASE);
         assert_eq!((calls[0].value, calls[0].index), (0, 0));
         assert!(calls[0].data.is_empty());
@@ -264,17 +266,20 @@ mod tests {
         let (transport, device) = mock_device();
         device.spiflash_write(0x0A_BCDE, &[1, 2, 3]).expect("write");
         let calls = transport.take_recorded();
+        assert_eq!(calls.len(), 1);
         let c = &calls[0];
         assert_eq!(c.request, wire::SPIFLASH_WRITE);
         // address >> 16 = 0x0A; address & 0xFFFF = 0xBCDE.
         assert_eq!((c.value, c.index), (0x0A, 0xBCDE));
         assert_eq!(c.data, vec![1, 2, 3]);
 
-        // C: address > 0x0FFFFF → AIRSPY_ERROR_INVALID_PARAM.
+        // C: address > 0x0FFFFF → AIRSPY_ERROR_INVALID_PARAM, checked
+        // before any transfer — nothing may reach the wire.
         assert!(matches!(
             device.spiflash_write(0x10_0000, &[0]),
             Err(crate::Error::InvalidParam)
         ));
+        assert!(transport.take_recorded().is_empty());
     }
 
     #[test]
@@ -284,7 +289,9 @@ mod tests {
         let mut buf = [0u8; 4];
         device.spiflash_read(0x01_0002, &mut buf).expect("read");
         assert_eq!(buf, [9, 8, 7, 6]);
-        let c = &transport.take_recorded()[0];
+        let calls = transport.take_recorded();
+        assert_eq!(calls.len(), 1);
+        let c = &calls[0];
         assert_eq!(c.request, wire::SPIFLASH_READ);
         assert_eq!((c.value, c.index), (0x01, 0x0002));
         assert_eq!(c.data.len(), 4);

--- a/crates/libairspy/src/peripherals.rs
+++ b/crates/libairspy/src/peripherals.rs
@@ -9,16 +9,29 @@
 use crate::commands::{Command, GpioPin, GpioPort};
 use crate::device::Device;
 use crate::error::{Error, Result};
-use crate::transfer::NO_WVALUE;
+use crate::transfer::{NO_WINDEX, NO_WVALUE};
 
 /// `airspy_spiflash_write`'s address bound: `address > 0x0FFFFF` is
 /// `AIRSPY_ERROR_INVALID_PARAM` (airspy.c).
 const SPIFLASH_MAX_ADDRESS: u32 = 0x000F_FFFF;
 
+/// Bits the port number occupies above the pin in the `port_pin`
+/// packing — the `((uint8_t)port) << 5` shift shared by every GPIO
+/// function in airspy.c.
+const GPIO_PORT_SHIFT: u8 = 5;
+
+/// Bits the low half of a SPI-flash address occupies in `wIndex` —
+/// the `address >> 16` / `address & 0xFFFF` split in
+/// `airspy_spiflash_write` and `airspy_spiflash_read` (airspy.c).
+const SPIFLASH_ADDR_LOW_BITS: u32 = 16;
+/// Mask selecting that low half (`address & 0xFFFF` in the same C
+/// functions).
+const SPIFLASH_ADDR_LOW_MASK: u32 = 0xFFFF;
+
 /// Pack `port << 5 | pin` (the `port_pin` computation shared by every
 /// GPIO function in airspy.c).
 fn port_pin(port: GpioPort, pin: GpioPin) -> u16 {
-    u16::from((port as u8) << 5 | pin as u8)
+    u16::from((port as u8) << GPIO_PORT_SHIFT | pin as u8)
 }
 
 impl Device {
@@ -95,7 +108,7 @@ impl Device {
     /// **Destructive**: this wipes the firmware image; only meaningful
     /// as part of a firmware-update flow with a new image ready.
     pub fn spiflash_erase(&self) -> Result<()> {
-        self.out_setter(Command::SpiflashErase, 0, 0, &[])
+        self.out_setter(Command::SpiflashErase, NO_WVALUE, NO_WINDEX, &[])
     }
 
     /// Erase one SPI-flash sector (`airspy_spiflash_erase_sector`).
@@ -104,7 +117,7 @@ impl Device {
     /// (0 and 1 are reserved) but the library does not validate, and
     /// neither does this port — the caller owns that judgment.
     pub fn spiflash_erase_sector(&self, sector: u16) -> Result<()> {
-        self.out_setter(Command::SpiflashEraseSector, sector, 0, &[])
+        self.out_setter(Command::SpiflashEraseSector, sector, NO_WINDEX, &[])
     }
 
     /// Write SPI flash (`airspy_spiflash_write`): the 20-bit address
@@ -125,8 +138,8 @@ impl Device {
         #[allow(clippy::cast_possible_truncation)]
         self.out_setter(
             Command::SpiflashWrite,
-            (address >> 16) as u16,
-            (address & 0xFFFF) as u16,
+            (address >> SPIFLASH_ADDR_LOW_BITS) as u16,
+            (address & SPIFLASH_ADDR_LOW_MASK) as u16,
             data,
         )
     }
@@ -141,8 +154,8 @@ impl Device {
         #[allow(clippy::cast_possible_truncation)]
         let n = self.vendor_in(
             Command::SpiflashRead,
-            (address >> 16) as u16,
-            (address & 0xFFFF) as u16,
+            (address >> SPIFLASH_ADDR_LOW_BITS) as u16,
+            (address & SPIFLASH_ADDR_LOW_MASK) as u16,
             buf,
         )?;
         if n < buf.len() {
@@ -167,6 +180,7 @@ mod tests {
         device.si5351c_write(0x10, 0xAB).expect("si");
         device.r820t_write(0x05, 0xCD).expect("r820t");
         let calls = transport.take_recorded();
+        assert_eq!(calls.len(), 2);
         for (c, (req, val, reg)) in calls.iter().zip([
             (wire::SI5351C_WRITE, 0xAB, 0x10),
             (wire::R820T_WRITE, 0xCD, 0x05),
@@ -186,6 +200,7 @@ mod tests {
         assert_eq!(device.si5351c_read(0x11).expect("si"), 0x5A);
         assert_eq!(device.r820t_read(0x06).expect("r820t"), 0xA5);
         let calls = transport.take_recorded();
+        assert_eq!(calls.len(), 2);
         for (c, (req, reg)) in calls
             .iter()
             .zip([(wire::SI5351C_READ, 0x11), (wire::R820T_READ, 0x06)])

--- a/crates/libairspy/src/peripherals.rs
+++ b/crates/libairspy/src/peripherals.rs
@@ -1,0 +1,277 @@
+//! Peripheral register and flash access, ported from `airspy.c`:
+//! si5351c / R820T register I/O, the GPIO surface, and SPI flash.
+//!
+//! The `airspy_config_read` / `airspy_config_write` declarations in
+//! `airspy.h` have **no implementation anywhere in the reference
+//! revision** (nothing in `airspy.c` or the tools references them), so
+//! this port omits them rather than inventing wire behavior.
+
+use crate::commands::{Command, GpioPin, GpioPort};
+use crate::device::Device;
+use crate::error::{Error, Result};
+use crate::transfer::NO_WVALUE;
+
+/// `airspy_spiflash_write`'s address bound: `address > 0x0FFFFF` is
+/// `AIRSPY_ERROR_INVALID_PARAM` (airspy.c).
+const SPIFLASH_MAX_ADDRESS: u32 = 0x000F_FFFF;
+
+/// Pack `port << 5 | pin` (the `port_pin` computation shared by every
+/// GPIO function in airspy.c).
+fn port_pin(port: GpioPort, pin: GpioPin) -> u16 {
+    u16::from((port as u8) << 5 | pin as u8)
+}
+
+impl Device {
+    /// Read one register-style byte: the IN pattern with the register
+    /// (or port/pin) in `wIndex`, returning the byte (`result < 1` →
+    /// the libusb error, as in C).
+    fn in_byte(&self, command: Command, index: u16) -> Result<u8> {
+        let mut value = [0u8; 1];
+        let n = self.vendor_in(command, NO_WVALUE, index, &mut value)?;
+        if n < value.len() {
+            return Err(Error::TransferLengthMismatch {
+                expected: value.len(),
+                actual: n,
+            });
+        }
+        Ok(value[0])
+    }
+
+    /// Write an si5351c clock-generator register
+    /// (`airspy_si5351c_write`).
+    pub fn si5351c_write(&self, register: u8, value: u8) -> Result<()> {
+        self.out_setter(
+            Command::Si5351cWrite,
+            u16::from(value),
+            u16::from(register),
+            &[],
+        )
+    }
+
+    /// Read an si5351c clock-generator register
+    /// (`airspy_si5351c_read`).
+    pub fn si5351c_read(&self, register: u8) -> Result<u8> {
+        self.in_byte(Command::Si5351cRead, u16::from(register))
+    }
+
+    /// Write an R820T tuner register (`airspy_r820t_write`).
+    pub fn r820t_write(&self, register: u8, value: u8) -> Result<()> {
+        self.out_setter(
+            Command::R820tWrite,
+            u16::from(value),
+            u16::from(register),
+            &[],
+        )
+    }
+
+    /// Read an R820T tuner register (`airspy_r820t_read`).
+    pub fn r820t_read(&self, register: u8) -> Result<u8> {
+        self.in_byte(Command::R820tRead, u16::from(register))
+    }
+
+    /// Read a GPIO level (`airspy_gpio_read`; 0 or 1).
+    pub fn gpio_read(&self, port: GpioPort, pin: GpioPin) -> Result<u8> {
+        self.in_byte(Command::GpioRead, port_pin(port, pin))
+    }
+
+    /// Set a GPIO direction (`airspy_gpiodir_write`; 0 = input,
+    /// 1 = output).
+    pub fn gpiodir_write(&self, port: GpioPort, pin: GpioPin, value: u8) -> Result<()> {
+        self.out_setter(
+            Command::GpiodirWrite,
+            u16::from(value),
+            port_pin(port, pin),
+            &[],
+        )
+    }
+
+    /// Read a GPIO direction (`airspy_gpiodir_read`).
+    pub fn gpiodir_read(&self, port: GpioPort, pin: GpioPin) -> Result<u8> {
+        self.in_byte(Command::GpiodirRead, port_pin(port, pin))
+    }
+
+    /// Erase the entire SPI flash (`airspy_spiflash_erase`).
+    ///
+    /// **Destructive**: this wipes the firmware image; only meaningful
+    /// as part of a firmware-update flow with a new image ready.
+    pub fn spiflash_erase(&self) -> Result<()> {
+        self.out_setter(Command::SpiflashErase, 0, 0, &[])
+    }
+
+    /// Erase one SPI-flash sector (`airspy_spiflash_erase_sector`).
+    ///
+    /// **Destructive**. The C header documents sectors 2–13 as valid
+    /// (0 and 1 are reserved) but the library does not validate, and
+    /// neither does this port — the caller owns that judgment.
+    pub fn spiflash_erase_sector(&self, sector: u16) -> Result<()> {
+        self.out_setter(Command::SpiflashEraseSector, sector, 0, &[])
+    }
+
+    /// Write SPI flash (`airspy_spiflash_write`): the 20-bit address
+    /// splits across `wValue` (high) and `wIndex` (low); addresses
+    /// above `0x0FFFFF` are `InvalidParam` like C.
+    ///
+    /// **Destructive**: can corrupt firmware or calibration if
+    /// misused.
+    pub fn spiflash_write(&self, address: u32, data: &[u8]) -> Result<()> {
+        if address > SPIFLASH_MAX_ADDRESS {
+            return Err(Error::InvalidParam);
+        }
+        // C's length parameter is uint16_t; a larger slice cannot be
+        // expressed on the wire.
+        if u16::try_from(data.len()).is_err() {
+            return Err(Error::InvalidParam);
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        self.out_setter(
+            Command::SpiflashWrite,
+            (address >> 16) as u16,
+            (address & 0xFFFF) as u16,
+            data,
+        )
+    }
+
+    /// Read SPI flash (`airspy_spiflash_read`) into `buf` (same
+    /// address packing as the write; C performs no address check on
+    /// reads and neither does this port).
+    pub fn spiflash_read(&self, address: u32, buf: &mut [u8]) -> Result<()> {
+        if u16::try_from(buf.len()).is_err() {
+            return Err(Error::InvalidParam);
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        let n = self.vendor_in(
+            Command::SpiflashRead,
+            (address >> 16) as u16,
+            (address & 0xFFFF) as u16,
+            buf,
+        )?;
+        if n < buf.len() {
+            return Err(Error::TransferLengthMismatch {
+                expected: buf.len(),
+                actual: n,
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::commands::{GpioPin, GpioPort};
+    use crate::control::tests::mock_device;
+    use crate::transport::mock::wire;
+
+    #[test]
+    fn si5351c_and_r820t_register_writes() {
+        let (transport, device) = mock_device();
+        device.si5351c_write(0x10, 0xAB).expect("si");
+        device.r820t_write(0x05, 0xCD).expect("r820t");
+        let calls = transport.take_recorded();
+        for (c, (req, val, reg)) in calls.iter().zip([
+            (wire::SI5351C_WRITE, 0xAB, 0x10),
+            (wire::R820T_WRITE, 0xCD, 0x05),
+        ]) {
+            assert_eq!(c.request_type, wire::VENDOR_OUT);
+            assert_eq!(c.request, req);
+            assert_eq!((c.value, c.index), (val, reg));
+            assert!(c.data.is_empty());
+            assert_eq!(c.timeout, wire::CTRL_TIMEOUT);
+        }
+    }
+
+    #[test]
+    fn si5351c_and_r820t_register_reads() {
+        let (transport, device) = mock_device();
+        transport.script_reads(vec![Ok(vec![0x5A]), Ok(vec![0xA5])]);
+        assert_eq!(device.si5351c_read(0x11).expect("si"), 0x5A);
+        assert_eq!(device.r820t_read(0x06).expect("r820t"), 0xA5);
+        let calls = transport.take_recorded();
+        for (c, (req, reg)) in calls
+            .iter()
+            .zip([(wire::SI5351C_READ, 0x11), (wire::R820T_READ, 0x06)])
+        {
+            assert_eq!(c.request_type, wire::VENDOR_IN);
+            assert_eq!(c.request, req);
+            assert_eq!((c.value, c.index), (0, reg));
+            assert_eq!(c.data.len(), 1);
+        }
+    }
+
+    #[test]
+    fn gpio_surface_encodes_port_pin() {
+        let (transport, device) = mock_device();
+        transport.script_reads(vec![Ok(vec![1]), Ok(vec![0])]);
+        device
+            .gpio_write(GpioPort::Port2, GpioPin::Pin7, 1)
+            .expect("write");
+        assert_eq!(
+            device
+                .gpio_read(GpioPort::Port2, GpioPin::Pin7)
+                .expect("read"),
+            1
+        );
+        device
+            .gpiodir_write(GpioPort::Port0, GpioPin::Pin31, 1)
+            .expect("dir write");
+        assert_eq!(
+            device
+                .gpiodir_read(GpioPort::Port0, GpioPin::Pin31)
+                .expect("dir read"),
+            0
+        );
+        let calls = transport.take_recorded();
+        // port 2 << 5 | pin 7 = 71; port 0 << 5 | pin 31 = 31.
+        assert_eq!(calls[0].request, wire::GPIO_WRITE);
+        assert_eq!((calls[0].value, calls[0].index), (1, 71));
+        assert_eq!(calls[1].request, wire::GPIO_READ);
+        assert_eq!((calls[1].value, calls[1].index), (0, 71));
+        assert_eq!(calls[2].request, wire::GPIODIR_WRITE);
+        assert_eq!((calls[2].value, calls[2].index), (1, 31));
+        assert_eq!(calls[3].request, wire::GPIODIR_READ);
+        assert_eq!((calls[3].value, calls[3].index), (0, 31));
+    }
+
+    #[test]
+    fn spiflash_erase_variants() {
+        let (transport, device) = mock_device();
+        device.spiflash_erase().expect("erase");
+        device.spiflash_erase_sector(5).expect("sector");
+        let calls = transport.take_recorded();
+        assert_eq!(calls[0].request, wire::SPIFLASH_ERASE);
+        assert_eq!((calls[0].value, calls[0].index), (0, 0));
+        assert!(calls[0].data.is_empty());
+        assert_eq!(calls[1].request, wire::SPIFLASH_ERASE_SECTOR);
+        assert_eq!((calls[1].value, calls[1].index), (5, 0));
+    }
+
+    #[test]
+    fn spiflash_write_splits_address_and_validates() {
+        let (transport, device) = mock_device();
+        device.spiflash_write(0x0A_BCDE, &[1, 2, 3]).expect("write");
+        let calls = transport.take_recorded();
+        let c = &calls[0];
+        assert_eq!(c.request, wire::SPIFLASH_WRITE);
+        // address >> 16 = 0x0A; address & 0xFFFF = 0xBCDE.
+        assert_eq!((c.value, c.index), (0x0A, 0xBCDE));
+        assert_eq!(c.data, vec![1, 2, 3]);
+
+        // C: address > 0x0FFFFF → AIRSPY_ERROR_INVALID_PARAM.
+        assert!(matches!(
+            device.spiflash_write(0x10_0000, &[0]),
+            Err(crate::Error::InvalidParam)
+        ));
+    }
+
+    #[test]
+    fn spiflash_read_splits_address_and_fills() {
+        let (transport, device) = mock_device();
+        transport.script_reads(vec![Ok(vec![9, 8, 7, 6])]);
+        let mut buf = [0u8; 4];
+        device.spiflash_read(0x01_0002, &mut buf).expect("read");
+        assert_eq!(buf, [9, 8, 7, 6]);
+        let c = &transport.take_recorded()[0];
+        assert_eq!(c.request, wire::SPIFLASH_READ);
+        assert_eq!((c.value, c.index), (0x01, 0x0002));
+        assert_eq!(c.data.len(), 4);
+    }
+}

--- a/crates/libairspy/src/peripherals.rs
+++ b/crates/libairspy/src/peripherals.rs
@@ -209,6 +209,7 @@ mod tests {
             assert_eq!(c.request, req);
             assert_eq!((c.value, c.index), (0, reg));
             assert_eq!(c.data.len(), 1);
+            assert_eq!(c.timeout, wire::CTRL_TIMEOUT);
         }
     }
 
@@ -236,6 +237,17 @@ mod tests {
         );
         let calls = transport.take_recorded();
         assert_eq!(calls.len(), 4);
+        // Writes are vendor-OUT, reads vendor-IN, all on the shared
+        // control timeout.
+        for (c, direction) in calls.iter().zip([
+            wire::VENDOR_OUT,
+            wire::VENDOR_IN,
+            wire::VENDOR_OUT,
+            wire::VENDOR_IN,
+        ]) {
+            assert_eq!(c.request_type, direction);
+            assert_eq!(c.timeout, wire::CTRL_TIMEOUT);
+        }
         // port 2 << 5 | pin 7 = 71; port 0 << 5 | pin 31 = 31.
         assert_eq!(calls[0].request, wire::GPIO_WRITE);
         assert_eq!((calls[0].value, calls[0].index), (1, 71));
@@ -254,6 +266,10 @@ mod tests {
         device.spiflash_erase_sector(5).expect("sector");
         let calls = transport.take_recorded();
         assert_eq!(calls.len(), 2);
+        for c in &calls {
+            assert_eq!(c.request_type, wire::VENDOR_OUT);
+            assert_eq!(c.timeout, wire::CTRL_TIMEOUT);
+        }
         assert_eq!(calls[0].request, wire::SPIFLASH_ERASE);
         assert_eq!((calls[0].value, calls[0].index), (0, 0));
         assert!(calls[0].data.is_empty());
@@ -268,7 +284,9 @@ mod tests {
         let calls = transport.take_recorded();
         assert_eq!(calls.len(), 1);
         let c = &calls[0];
+        assert_eq!(c.request_type, wire::VENDOR_OUT);
         assert_eq!(c.request, wire::SPIFLASH_WRITE);
+        assert_eq!(c.timeout, wire::CTRL_TIMEOUT);
         // address >> 16 = 0x0A; address & 0xFFFF = 0xBCDE.
         assert_eq!((c.value, c.index), (0x0A, 0xBCDE));
         assert_eq!(c.data, vec![1, 2, 3]);
@@ -292,8 +310,41 @@ mod tests {
         let calls = transport.take_recorded();
         assert_eq!(calls.len(), 1);
         let c = &calls[0];
+        assert_eq!(c.request_type, wire::VENDOR_IN);
         assert_eq!(c.request, wire::SPIFLASH_READ);
+        assert_eq!(c.timeout, wire::CTRL_TIMEOUT);
         assert_eq!((c.value, c.index), (0x01, 0x0002));
         assert_eq!(c.data.len(), 4);
+    }
+
+    #[test]
+    fn spiflash_length_boundary() {
+        let (transport, device) = mock_device();
+        // The largest length C's uint16_t parameter can express goes
+        // through unchanged for both directions...
+        let max_len = usize::from(u16::MAX);
+        device
+            .spiflash_write(0, &vec![0u8; max_len])
+            .expect("max write");
+        transport.script_reads(vec![Ok(vec![0xEE; max_len])]);
+        let mut buf = vec![0u8; max_len];
+        device.spiflash_read(0, &mut buf).expect("max read");
+        let calls = transport.take_recorded();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].data.len(), max_len);
+        assert_eq!(calls[1].data.len(), max_len);
+        // ...and one byte past it is unrepresentable on the wire:
+        // InvalidParam with nothing recorded (documented deviation —
+        // the C API cannot express this length at all).
+        assert!(matches!(
+            device.spiflash_write(0, &vec![0u8; max_len + 1]),
+            Err(crate::Error::InvalidParam)
+        ));
+        let mut over = vec![0u8; max_len + 1];
+        assert!(matches!(
+            device.spiflash_read(0, &mut over),
+            Err(crate::Error::InvalidParam)
+        ));
+        assert!(transport.take_recorded().is_empty());
     }
 }

--- a/crates/libairspy/src/peripherals.rs
+++ b/crates/libairspy/src/peripherals.rs
@@ -269,10 +269,10 @@ mod tests {
         for c in &calls {
             assert_eq!(c.request_type, wire::VENDOR_OUT);
             assert_eq!(c.timeout, wire::CTRL_TIMEOUT);
+            assert!(c.data.is_empty());
         }
         assert_eq!(calls[0].request, wire::SPIFLASH_ERASE);
         assert_eq!((calls[0].value, calls[0].index), (0, 0));
-        assert!(calls[0].data.is_empty());
         assert_eq!(calls[1].request, wire::SPIFLASH_ERASE_SECTOR);
         assert_eq!((calls[1].value, calls[1].index), (5, 0));
     }

--- a/crates/libairspy/src/transport.rs
+++ b/crates/libairspy/src/transport.rs
@@ -125,6 +125,28 @@ pub(crate) mod mock {
         pub(crate) const GPIO_WRITE: u8 = 21;
         /// `AIRSPY_SET_PACKING = 26` (`airspy_commands.h`).
         pub(crate) const SET_PACKING: u8 = 26;
+        /// `AIRSPY_SI5351C_WRITE = 2` (`airspy_commands.h`).
+        pub(crate) const SI5351C_WRITE: u8 = 2;
+        /// `AIRSPY_SI5351C_READ = 3` (`airspy_commands.h`).
+        pub(crate) const SI5351C_READ: u8 = 3;
+        /// `AIRSPY_R820T_WRITE = 4` (`airspy_commands.h`).
+        pub(crate) const R820T_WRITE: u8 = 4;
+        /// `AIRSPY_R820T_READ = 5` (`airspy_commands.h`).
+        pub(crate) const R820T_READ: u8 = 5;
+        /// `AIRSPY_SPIFLASH_ERASE = 6` (`airspy_commands.h`).
+        pub(crate) const SPIFLASH_ERASE: u8 = 6;
+        /// `AIRSPY_SPIFLASH_WRITE = 7` (`airspy_commands.h`).
+        pub(crate) const SPIFLASH_WRITE: u8 = 7;
+        /// `AIRSPY_SPIFLASH_READ = 8` (`airspy_commands.h`).
+        pub(crate) const SPIFLASH_READ: u8 = 8;
+        /// `AIRSPY_GPIO_READ = 22` (`airspy_commands.h`).
+        pub(crate) const GPIO_READ: u8 = 22;
+        /// `AIRSPY_GPIODIR_WRITE = 23` (`airspy_commands.h`).
+        pub(crate) const GPIODIR_WRITE: u8 = 23;
+        /// `AIRSPY_GPIODIR_READ = 24` (`airspy_commands.h`).
+        pub(crate) const GPIODIR_READ: u8 = 24;
+        /// `AIRSPY_SPIFLASH_ERASE_SECTOR = 27` (`airspy_commands.h`).
+        pub(crate) const SPIFLASH_ERASE_SECTOR: u8 = 27;
         /// OUT|VENDOR|DEVICE (airspy.c's host-to-device transfers).
         pub(crate) const VENDOR_OUT: u8 = 0x40;
         /// IN|VENDOR|DEVICE (airspy.c's device-to-host transfers).


### PR DESCRIPTION
## Summary

Combined PR for the three sibling M4 peripheral issues, closing out the device-control surface:

- **#23 — si5351c and R820T register access**: `si5351c_write/read`, `r820t_write/read`. Writes are OUT requests with the value in `wValue` and register in `wIndex`, empty payload, C's `result != 0` check (via the shared `out_setter`). Reads are IN requests for one byte with C's `result < 1` check (new shared `in_byte` helper).
- **#24 — GPIO and GPIO-direction access**: `gpio_read`, `gpiodir_write`, `gpiodir_read` added; `gpio_write` (already used internally by `set_rf_bias`) promoted to `pub`. All four pack `port << 5 | pin` into `wIndex` exactly as C's `port_pin` computation, using the existing `GpioPort`/`GpioPin` enums.
- **#25 — SPI flash**: `spiflash_erase`, `spiflash_erase_sector`, `spiflash_write`, `spiflash_read`. Write validates `address > 0x0FFFFF` → `InvalidParam` and splits the 20-bit address across `wValue` (high) / `wIndex` (low); read uses the same split and — faithful to C — performs **no** address check. Destructive operations carry explicit danger docs; `erase_sector` documents the header's sectors-2–13 note but, like C, does not validate.

## Finding: `airspy_config_write/read` are phantom declarations

Issue #25 lists `airspy_config_read/write`, but in the reference revision they exist **only as declarations in `airspy.h`** — no implementation in `airspy.c`, no callers anywhere in the tree. There is no wire behavior to port, so they are omitted (documented in the `peripherals` module header). Will note this when the issue closes.

## Deviation

C's `length` parameter is `uint16_t`, so transfers over 64 KiB are unrepresentable in the C API. The slice-based Rust API returns `InvalidParam` for oversized buffers rather than silently truncating (documented inline).

## Testing

TDD (RED → GREEN). Six new transport-boundary tests in `peripherals.rs` assert `bmRequestType`/`bRequest`/`wValue`/`wIndex`/payload/timeout against independently transcribed `wire` constants (11 new: `SI5351C_WRITE/READ`, `R820T_WRITE/READ`, `SPIFLASH_ERASE/WRITE/READ/ERASE_SECTOR`, `GPIO_READ`, `GPIODIR_WRITE/READ`), covering register round-trips, both GPIO `port_pin` encodings (`Port2/Pin7` → 71, `Port0/Pin31` → 31), both erase variants, the flash address split (`0x0ABCDE` → `0x0A`/`0xBCDE`), the `0x10_0000` rejection, and read buffer fill.

118 tests pass; fmt/clippy (`-D warnings`, all features)/doc (`-D warnings`) clean.

Closes #23, closes #24, closes #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added access to Si5351C and R820T device registers.
  * Added GPIO reading, writing, and direction-control operations.
  * Added SPI flash erase, read, and write capabilities.
  * Added validation for flash addresses, transfer sizes, and incomplete reads.
  * Improved USB communication with device peripherals and hardware controls.

* **Tests**
  * Added coverage for register access, GPIO operations, flash handling, command encoding, validation, and transfer results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->