### PR TITLE
M5: airspy_rx capture tool (#26)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,8 +6,19 @@ version = 4
 name = "airspy-tools"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "clap",
+ "ctrlc",
  "libairspy-rs",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -85,6 +96,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "blocking"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "cc"
 version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +143,29 @@ checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
 ]
 
 [[package]]
@@ -163,10 +224,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
 
 [[package]]
 name = "event-listener"
@@ -223,16 +313,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libairspy-rs"
@@ -264,6 +407,48 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -335,10 +520,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "strsim"
@@ -447,10 +644,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tracing = "0.1"
 # CLI (airspy-tools)
 clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-ctrlc = "3"
+ctrlc = { version = "3", features = ["termination"] }
 
 # Async-runtime integrations (optional, feature-gated in libairspy-rs;
 # same pattern as librtlsdr-rs)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ tracing = "0.1"
 
 # CLI (airspy-tools)
 clap = { version = "4", features = ["derive"] }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+ctrlc = "3"
 
 # Async-runtime integrations (optional, feature-gated in libairspy-rs;
 # same pattern as librtlsdr-rs)

--- a/crates/airspy-tools/Cargo.toml
+++ b/crates/airspy-tools/Cargo.toml
@@ -11,6 +11,8 @@ publish = false
 [dependencies]
 libairspy-rs.workspace = true
 clap.workspace = true
+chrono.workspace = true
+ctrlc.workspace = true
 
 [lints]
 workspace = true

--- a/crates/airspy-tools/src/bin/airspy_rx.rs
+++ b/crates/airspy-tools/src/bin/airspy_rx.rs
@@ -10,14 +10,18 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Instant;
 
 use airspy_tools::rx::{
-    FD_BUFFER_SIZE, RateTracker, extend_sample_bytes, frame_count, resolve_display_rate,
-    wav_header_finalized, wav_header_placeholder,
+    FD_BUFFER_SIZE, RateTracker, WAV_MAX_DATA_BYTES, extend_sample_bytes, frame_count,
+    resolve_display_rate, wav_header_finalized, wav_header_placeholder,
 };
 use airspy_tools::rx_cli::{Args, Config, build_config, print_verbose, usage};
 use clap::Parser;
 use libairspy_rs::commands::SampleType;
 use libairspy_rs::stream::Transfer;
 use libairspy_rs::{Device, Error};
+
+/// The `0.000001f` Hz→MSPS factor in the C tool's verbose
+/// `sample_rate -a` print (`airspy_rx.c` `main()`).
+const HZ_TO_MSPS: f64 = 0.000_001;
 
 /// One second — the C main loop's `sleep(1)` cadence.
 const LOOP_SLEEP: std::time::Duration = std::time::Duration::from_secs(1);
@@ -35,10 +39,14 @@ fn print_error(context: &str, err: &Error) {
 struct RxShared {
     writer: Option<Box<dyn Write + Send>>,
     tracker: RateTracker,
-    /// Remaining byte budget when `-n` was given.
+    /// Remaining byte budget: the `-n` limit, the WAV data cap, or
+    /// both (minimum).
     remaining: Option<u64>,
     /// Reused per-block byte buffer.
     buf: Vec<u8>,
+    /// Set when an output write failed — the capture is truncated and
+    /// the exit status must be nonzero.
+    write_failed: bool,
 }
 
 /// Lock the shared state, recovering from a poisoned mutex (a panic
@@ -81,6 +89,9 @@ fn on_transfer(
         return false;
     };
     if writer.write_all(&state.buf[..bytes_to_write]).is_err() {
+        // Recorded so the exit status reflects the truncated capture
+        // (C's write-error stop keeps returning EXIT_SUCCESS).
+        state.write_failed = true;
         return false;
     }
     // C: stop once the byte budget is exhausted.
@@ -112,7 +123,7 @@ fn print_samplerate(config: &Config, wav_sample_per_sec: u32) {
     eprintln!(
         "sample_rate -a {} ({:.6} MSPS {})",
         config.sample_rate_val,
-        f64::from(wav_sample_per_sec) * 0.000_001,
+        f64::from(wav_sample_per_sec) * HZ_TO_MSPS,
         if config.wav_params.channels == 1 {
             "Real"
         } else {
@@ -245,7 +256,7 @@ fn apply_gains(device: &Device, config: &Config) {
 /// and — exactly as C does — flip `do_exit` when the `-n` byte budget
 /// empties (C then reports "User cancel, exiting...", the same as a
 /// signal stop).
-fn stream_loop(device: &Device, shared: &Mutex<RxShared>, config: &Config) {
+fn stream_loop(device: &Device, shared: &Mutex<RxShared>) {
     while device.is_streaming() && !DO_EXIT.load(Ordering::SeqCst) {
         let (average_rate, exhausted) = {
             let state = lock_shared(shared);
@@ -255,7 +266,9 @@ fn stream_loop(device: &Device, shared: &Mutex<RxShared>, config: &Config) {
             "Streaming at {:>5} MSPS",
             format!("{:.3}", average_rate * 1e-6)
         );
-        if config.limit_num_samples && exhausted {
+        if exhausted {
+            // C: do_exit = true when the -n budget empties (the WAV
+            // size cap uses the same mechanism).
             DO_EXIT.store(true, Ordering::SeqCst);
         } else {
             std::thread::sleep(LOOP_SLEEP);
@@ -350,11 +363,21 @@ fn run(config: &Config) -> i32 {
         return 1;
     };
 
+    // The -n byte budget, additionally capped at the RIFF size limit
+    // for WAV output so the finalized header stays representable
+    // (deviation: C wraps its uint32_t sizes past 4 GiB).
+    let limit = config.limit_num_samples.then_some(config.bytes_to_xfer);
+    let remaining = if config.receive_wav {
+        Some(limit.map_or(WAV_MAX_DATA_BYTES, |b| b.min(WAV_MAX_DATA_BYTES)))
+    } else {
+        limit
+    };
     let shared = Arc::new(Mutex::new(RxShared {
         writer: Some(writer),
         tracker: RateTracker::new(wav_sample_per_sec as f32),
-        remaining: config.limit_num_samples.then_some(config.bytes_to_xfer),
+        remaining,
         buf: Vec::new(),
+        write_failed: false,
     }));
 
     if config.receive_wav && write_wav_placeholder(config, &shared).is_err() {
@@ -384,7 +407,7 @@ fn run(config: &Config) -> i32 {
 
     eprintln!("Stop with Ctrl-C");
     std::thread::sleep(LOOP_SLEEP);
-    stream_loop(&device, &shared, config);
+    stream_loop(&device, &shared);
     print_summary(config, &shared, started);
 
     if let Err(err) = device.stop_rx() {
@@ -392,41 +415,59 @@ fn run(config: &Config) -> i32 {
     }
     drop(device);
 
-    finalize_output(config, &shared, wav_sample_per_sec);
+    let output_ok = finalize_output(config, &shared, wav_sample_per_sec);
     eprintln!("done");
-    0
+    // Deviation: C returns EXIT_SUCCESS even for truncated or
+    // unfinalized captures; a failed output surfaces as status 1.
+    i32::from(!output_ok)
 }
 
 /// The end-of-main file handling: flush and close the stream, then
 /// for WAV captures rewrite the header with the real sizes (C's
 /// `ftell` + rewind + `fwrite`).
-fn finalize_output(config: &Config, shared: &Mutex<RxShared>, wav_sample_per_sec: u32) {
-    let writer = lock_shared(shared).writer.take();
+fn finalize_output(config: &Config, shared: &Mutex<RxShared>, wav_sample_per_sec: u32) -> bool {
+    let (writer, write_failed) = {
+        let mut state = lock_shared(shared);
+        (state.writer.take(), state.write_failed)
+    };
+    let mut ok = !write_failed;
+    if write_failed {
+        eprintln!("Failed to write file: {}", config.path);
+    }
     if let Some(mut writer) = writer
         && writer.flush().is_err()
     {
         eprintln!("Failed to write file: {}", config.path);
+        ok = false;
     }
 
     if config.receive_wav
         && let Err(message) = rewrite_wav_header(config, wav_sample_per_sec)
     {
         eprintln!("{message}");
+        ok = false;
     }
+    ok
 }
 
-/// Reopen the finished capture and overwrite the 44-byte header. C
-/// stores `ftell`'s position in a `uint32_t`, so files past 4 GiB wrap
-/// the size fields (a WAV format limit); the truncating cast keeps
-/// that behavior.
-#[allow(clippy::cast_possible_truncation)]
+/// Reopen the finished capture and overwrite the 44-byte header.
+/// The streaming budget keeps `-w` files inside the RIFF limit, so
+/// an unrepresentable size here (deviation: C wrapped its `uint32_t`
+/// `ftell` position and wrote corrupt fields) can only mean outside
+/// interference — refuse to finalize rather than truncate.
 fn rewrite_wav_header(config: &Config, wav_sample_per_sec: u32) -> Result<(), String> {
     let fail = || format!("Failed to write file: {}", config.path);
     let mut file = std::fs::OpenOptions::new()
         .write(true)
         .open(&config.path)
         .map_err(|_| fail())?;
-    let file_pos = file.metadata().map_err(|_| fail())?.len() as u32;
+    let len = file.metadata().map_err(|_| fail())?.len();
+    let Ok(file_pos) = u32::try_from(len) else {
+        return Err(format!(
+            "{} exceeds the 4 GiB WAV size limit; header left unfinalized",
+            config.path
+        ));
+    };
     let header = wav_header_finalized(file_pos, &config.wav_params, wav_sample_per_sec);
     file.seek(SeekFrom::Start(0)).map_err(|_| fail())?;
     file.write_all(&header).map_err(|_| fail())?;

--- a/crates/airspy-tools/src/bin/airspy_rx.rs
+++ b/crates/airspy-tools/src/bin/airspy_rx.rs
@@ -9,335 +9,21 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Instant;
 
-use airspy_tools::parse_u64;
 use airspy_tools::rx::{
-    BIAST_MAX, DEFAULT_FREQ_HZ, DEFAULT_LNA_GAIN, DEFAULT_MIXER_GAIN, DEFAULT_VGA_IF_GAIN,
-    FD_BUFFER_SIZE, FREQ_HZ_MAX, FREQ_HZ_MIN, FREQ_ONE_MHZ, LINEARITY_GAIN_MAX, LNA_GAIN_MAX,
-    MIXER_GAIN_MAX, RateTracker, SAMPLES_TO_XFER_MAX, SENSITIVITY_GAIN_MAX, VGA_GAIN_MAX,
-    WavParams, bytes_to_xfer, extend_sample_bytes, frame_count, parse_freq_mhz, parse_u32,
-    resolve_display_rate, wav_filename, wav_header_finalized, wav_header_placeholder,
+    FD_BUFFER_SIZE, RateTracker, extend_sample_bytes, frame_count, resolve_display_rate,
+    wav_header_finalized, wav_header_placeholder,
 };
+use airspy_tools::rx_cli::{Args, Config, build_config, print_verbose, usage};
 use clap::Parser;
 use libairspy_rs::commands::SampleType;
 use libairspy_rs::stream::Transfer;
 use libairspy_rs::{Device, Error};
-
-/// `AIRSPY_RX_VERSION` in `airspy_rx.c`.
-const AIRSPY_RX_VERSION: &str = "1.0.5 23 April 2016";
 
 /// One second — the C main loop's `sleep(1)` cadence.
 const LOOP_SLEEP: std::time::Duration = std::time::Duration::from_secs(1);
 
 /// `do_exit` in `airspy_rx.c`, flipped by the signal handler.
 static DO_EXIT: AtomicBool = AtomicBool::new(false);
-
-#[derive(Parser)]
-#[command(
-    name = "airspy_rx",
-    about = "Receive Airspy samples into a file",
-    disable_help_flag = true
-)]
-struct Args {
-    /// Receive data into file
-    #[arg(short = 'r', value_name = "filename")]
-    receive_file: Option<String>,
-
-    /// Receive data into file with WAV header and automatic name
-    #[arg(short = 'w')]
-    receive_wav: bool,
-
-    /// Open device with specified 64bits serial number
-    #[arg(short = 's', value_name = "serial_number_64bits", value_parser = parse_u64)]
-    serial_number: Option<u64>,
-
-    /// Set packing for samples: 1=enabled(12bits packed), 0=disabled
-    #[arg(short = 'p', value_name = "packing", value_parser = parse_u32)]
-    packing: Option<u32>,
-
-    /// Set frequency in MHz
-    #[arg(short = 'f', value_name = "frequency_MHz")]
-    freq_mhz: Option<String>,
-
-    /// Set sample rate (index or Hz)
-    #[arg(short = 'a', value_name = "sample_rate", value_parser = parse_u32)]
-    sample_rate: Option<u32>,
-
-    /// Set sample type: 0=`FLOAT32_IQ`, 1=`FLOAT32_REAL`, 2=`INT16_IQ`,
-    /// 3=`INT16_REAL`, 4=`U16_REAL`, 5=RAW
-    #[arg(short = 't', value_name = "sample_type", value_parser = parse_u32)]
-    sample_type: Option<u32>,
-
-    /// Set Bias Tee: 1=enabled, 0=disabled
-    #[arg(short = 'b', value_name = "biast", value_parser = parse_u32)]
-    biast: Option<u32>,
-
-    /// Set VGA/IF gain, 0-15
-    #[arg(short = 'v', value_name = "vga_gain", value_parser = parse_u32)]
-    vga_gain: Option<u32>,
-
-    /// Set Mixer gain, 0-15
-    #[arg(short = 'm', value_name = "mixer_gain", value_parser = parse_u32)]
-    mixer_gain: Option<u32>,
-
-    /// Set LNA gain, 0-14
-    #[arg(short = 'l', value_name = "lna_gain", value_parser = parse_u32)]
-    lna_gain: Option<u32>,
-
-    /// Set linearity simplified gain, 0-21
-    #[arg(short = 'g', value_name = "linearity_gain", value_parser = parse_u32)]
-    linearity_gain: Option<u32>,
-
-    /// Set sensitivity simplified gain, 0-21 (C's -h; use --help for
-    /// this text)
-    #[arg(short = 'h', value_name = "sensitivity_gain", value_parser = parse_u32)]
-    sensitivity_gain: Option<u32>,
-
-    /// Number of samples to transfer (default is unlimited)
-    #[arg(short = 'n', value_name = "num_samples", value_parser = parse_u64)]
-    num_samples: Option<u64>,
-
-    /// Verbose mode
-    #[arg(short = 'd')]
-    verbose: bool,
-
-    /// Print help
-    #[arg(long, action = clap::ArgAction::Help)]
-    help: Option<bool>,
-}
-
-/// The `usage()` text from `airspy_rx.c`, printed after argument
-/// errors.
-fn usage() {
-    eprintln!("airspy_rx v{AIRSPY_RX_VERSION}");
-    eprintln!("Usage:");
-    eprintln!("-r <filename>: Receive data into file");
-    eprintln!("-w Receive data into file with WAV header and automatic name");
-    eprintln!(" This is for SDR# compatibility and may not work with other software");
-    eprintln!("[-s serial_number_64bits]: Open device with specified 64bits serial number");
-    eprintln!("[-p packing]: Set packing for samples, ");
-    eprintln!(" 1=enabled(12bits packed), 0=disabled(default 16bits not packed)");
-    eprintln!(
-        "[-f frequency_MHz]: Set frequency in MHz between [{}, {}] (default {}MHz)",
-        FREQ_HZ_MIN / FREQ_ONE_MHZ,
-        FREQ_HZ_MAX / FREQ_ONE_MHZ,
-        DEFAULT_FREQ_HZ / FREQ_ONE_MHZ
-    );
-    eprintln!("[-a sample_rate]: Set sample rate");
-    eprintln!("[-t sample_type]: Set sample type, ");
-    eprintln!(
-        " 0=FLOAT32_IQ, 1=FLOAT32_REAL, 2=INT16_IQ(default), 3=INT16_REAL, 4=U16_REAL, 5=RAW"
-    );
-    eprintln!("[-b biast]: Set Bias Tee, 1=enabled, 0=disabled(default)");
-    eprintln!("[-v vga_gain]: Set VGA/IF gain, 0-{VGA_GAIN_MAX} (default {DEFAULT_VGA_IF_GAIN})");
-    eprintln!("[-m mixer_gain]: Set Mixer gain, 0-{MIXER_GAIN_MAX} (default {DEFAULT_MIXER_GAIN})");
-    eprintln!("[-l lna_gain]: Set LNA gain, 0-{LNA_GAIN_MAX} (default {DEFAULT_LNA_GAIN})");
-    eprintln!("[-g linearity_gain]: Set linearity simplified gain, 0-{LINEARITY_GAIN_MAX}");
-    eprintln!("[-h sensivity_gain]: Set sensitivity simplified gain, 0-{SENSITIVITY_GAIN_MAX}");
-    eprintln!("[-n num_samples]: Number of samples to transfer (default is unlimited)");
-    eprintln!("[-d]: Verbose mode");
-}
-
-/// The validated capture parameters, C's checked globals after the
-/// argument section of `main()`.
-// The bools mirror the C tool's independent flag globals.
-#[allow(clippy::struct_excessive_bools)]
-#[derive(Debug)]
-struct Config {
-    path: String,
-    receive_wav: bool,
-    serial_number: Option<u64>,
-    packing: bool,
-    call_set_packing: bool,
-    freq_hz: u32,
-    sample_rate_val: u32,
-    sample_type: SampleType,
-    wav_params: WavParams,
-    biast: bool,
-    vga_gain: u32,
-    mixer_gain: u32,
-    lna_gain: u32,
-    linearity_gain: Option<u32>,
-    sensitivity_gain: Option<u32>,
-    limit_num_samples: bool,
-    samples_to_xfer: u64,
-    bytes_to_xfer: u64,
-    verbose: bool,
-}
-
-/// The `-t` value → sample type mapping from the C switch (`None` is
-/// the out-of-range marker checked later).
-fn sample_type_from_u32(value: u32) -> Option<SampleType> {
-    match value {
-        0 => Some(SampleType::Float32Iq),
-        1 => Some(SampleType::Float32Real),
-        2 => Some(SampleType::Int16Iq),
-        3 => Some(SampleType::Int16Real),
-        4 => Some(SampleType::Uint16Real),
-        5 => Some(SampleType::Raw),
-        _ => None,
-    }
-}
-
-/// Every post-getopt validation from `airspy_rx.c` `main()`, in C's order
-/// and with C's stderr messages. `date_time` is the pre-formatted
-/// `%Y%m%d_%H%M%S` local time for the `-w` automatic filename.
-///
-/// Deviation: C's `-b` case sets the *`serial_number`* flag instead of
-/// a bias-T flag (a copy-paste bug that makes a bare `-b 1` open
-/// serial number 0); here `-b` only controls the bias tee.
-#[allow(clippy::too_many_lines)]
-fn build_config(args: &Args, date_time: &str) -> Result<Config, String> {
-    let sample_type = match args.sample_type {
-        None => Some(SampleType::Int16Iq),
-        Some(v) => sample_type_from_u32(v),
-    };
-    // The WAV parameters fall back to the int16 defaults while the
-    // sample type is invalid, exactly as C's globals do; the
-    // sample_type range check below fires before they are used.
-    let wav_params = WavParams::for_sample_type(sample_type.unwrap_or(SampleType::Int16Iq));
-
-    let samples_to_xfer = args.num_samples.unwrap_or(0);
-    let effective_type = sample_type.unwrap_or(SampleType::Int16Iq);
-    let packing = args.packing == Some(1);
-    let bytes = bytes_to_xfer(samples_to_xfer, &wav_params, effective_type, packing);
-
-    if samples_to_xfer >= SAMPLES_TO_XFER_MAX {
-        return Err(format!(
-            "argument error: num_samples must be less than {SAMPLES_TO_XFER_MAX}/{}Mio",
-            SAMPLES_TO_XFER_MAX / u64::from(FREQ_ONE_MHZ)
-        ));
-    }
-
-    let freq_hz = match &args.freq_mhz {
-        Some(s) => {
-            let hz = parse_freq_mhz(s);
-            if !(FREQ_HZ_MIN..FREQ_HZ_MAX).contains(&hz) {
-                return Err(format!(
-                    "argument error: frequency_MHz={:.6} MHz and shall be between [{}, {}[ MHz",
-                    f64::from(hz) / f64::from(FREQ_ONE_MHZ),
-                    FREQ_HZ_MIN / FREQ_ONE_MHZ,
-                    FREQ_HZ_MAX / FREQ_ONE_MHZ
-                ));
-            }
-            hz
-        }
-        None => DEFAULT_FREQ_HZ,
-    };
-
-    let path = if args.receive_wav {
-        if sample_type == Some(SampleType::Raw) {
-            return Err("The RAW sampling mode is not compatible with Wave files".into());
-        }
-        wav_filename(date_time, freq_hz)
-    } else {
-        match &args.receive_file {
-            Some(p) => p.clone(),
-            None => {
-                return Err(
-                    "error: you shall specify at least -r <with filename> or -w option".into(),
-                );
-            }
-        }
-    };
-
-    if let Some(p) = args.packing
-        && p > 1
-    {
-        return Err("argument error: packing out of range".into());
-    }
-    let Some(sample_type) = sample_type else {
-        return Err("argument error: sample_type out of range".into());
-    };
-    let biast_val = args.biast.unwrap_or(0);
-    if biast_val > BIAST_MAX {
-        return Err("argument error: biast_val out of range".into());
-    }
-    let vga_gain = args.vga_gain.unwrap_or(DEFAULT_VGA_IF_GAIN);
-    if vga_gain > VGA_GAIN_MAX {
-        return Err("argument error: vga_gain out of range".into());
-    }
-    let mixer_gain = args.mixer_gain.unwrap_or(DEFAULT_MIXER_GAIN);
-    if mixer_gain > MIXER_GAIN_MAX {
-        return Err("argument error: mixer_gain out of range".into());
-    }
-    let lna_gain = args.lna_gain.unwrap_or(DEFAULT_LNA_GAIN);
-    if lna_gain > LNA_GAIN_MAX {
-        return Err("argument error: lna_gain out of range".into());
-    }
-    if args.linearity_gain.unwrap_or(0) > LINEARITY_GAIN_MAX {
-        return Err("argument error: linearity_gain out of range".into());
-    }
-    if args.sensitivity_gain.unwrap_or(0) > SENSITIVITY_GAIN_MAX {
-        return Err("argument error: sensitivity_gain out of range".into());
-    }
-    if args.linearity_gain.is_some() && args.sensitivity_gain.is_some() {
-        return Err(
-            "argument error: linearity_gain and sensitivity_gain are both set (choose only one option)"
-                .into(),
-        );
-    }
-
-    Ok(Config {
-        path,
-        receive_wav: args.receive_wav,
-        serial_number: args.serial_number,
-        packing,
-        call_set_packing: args.packing.is_some(),
-        freq_hz,
-        sample_rate_val: args.sample_rate.unwrap_or(0),
-        sample_type,
-        wav_params,
-        biast: biast_val == 1,
-        vga_gain,
-        mixer_gain,
-        lna_gain,
-        linearity_gain: args.linearity_gain,
-        sensitivity_gain: args.sensitivity_gain,
-        limit_num_samples: args.num_samples.is_some(),
-        samples_to_xfer,
-        bytes_to_xfer: bytes,
-        verbose: args.verbose,
-    })
-}
-
-/// The `if (verbose)` argument dump in `airspy_rx.c` `main()`.
-fn print_verbose(config: &Config) {
-    eprintln!("airspy_rx v{AIRSPY_RX_VERSION}");
-    if let Some(serial) = config.serial_number {
-        eprintln!(
-            "serial_number_64bits -s 0x{:08X}{:08X}",
-            (serial >> 32) as u32,
-            (serial & 0xFFFF_FFFF) as u32
-        );
-    }
-    eprintln!("packing -p {}", u32::from(config.packing));
-    eprintln!(
-        "frequency_MHz -f {:.6}MHz ({}Hz)",
-        f64::from(config.freq_hz) / f64::from(FREQ_ONE_MHZ),
-        config.freq_hz
-    );
-    eprintln!("sample_type -t {}", config.sample_type as u8);
-    eprintln!("biast -b {}", u32::from(config.biast));
-    if config.linearity_gain.is_none() && config.sensitivity_gain.is_none() {
-        eprintln!("vga_gain -v {}", config.vga_gain);
-        eprintln!("mixer_gain -m {}", config.mixer_gain);
-        eprintln!("lna_gain -l {}", config.lna_gain);
-    } else {
-        if let Some(g) = config.linearity_gain {
-            eprintln!("linearity_gain -g {g}");
-        }
-        if let Some(g) = config.sensitivity_gain {
-            eprintln!("sensitivity_gain -h {g}");
-        }
-    }
-    if config.limit_num_samples {
-        eprintln!(
-            "num_samples -n {} ({}M)",
-            config.samples_to_xfer,
-            config.samples_to_xfer / u64::from(FREQ_ONE_MHZ)
-        );
-    }
-}
 
 /// `context() failed: name (code)` — the C error-print pattern.
 fn print_error(context: &str, err: &Error) {
@@ -421,6 +107,38 @@ fn main() {
     std::process::exit(run(&config));
 }
 
+/// The verbose `sample_rate -a` line from C `main()`.
+fn print_samplerate(config: &Config, wav_sample_per_sec: u32) {
+    eprintln!(
+        "sample_rate -a {} ({:.6} MSPS {})",
+        config.sample_rate_val,
+        f64::from(wav_sample_per_sec) * 0.000_001,
+        if config.wav_params.channels == 1 {
+            "Real"
+        } else {
+            "IQ"
+        }
+    );
+}
+
+/// The `airspy_board_partid_serialno_read` call and serial print
+/// from C `main()`.
+fn print_device_serial(device: &Device) -> Result<(), ()> {
+    match device.partid_serialno() {
+        Ok(partid_serialno) => {
+            eprintln!(
+                "Device Serial Number: 0x{:08X}{:08X}",
+                partid_serialno.serial_no[2], partid_serialno.serial_no[3]
+            );
+            Ok(())
+        }
+        Err(err) => {
+            print_error("airspy_board_partid_serialno_read()", &err);
+            Err(())
+        }
+    }
+}
+
 /// Open the device and apply the pre-stream configuration in C
 /// `main()`'s exact order: sample type, sample-rate resolution and
 /// set, serial-number print, packing, bias-T. Returns the device and
@@ -456,28 +174,10 @@ fn open_configured_device(config: &Config) -> Result<(Device, u32), ()> {
         return Err(());
     }
     if config.verbose {
-        eprintln!(
-            "sample_rate -a {} ({:.6} MSPS {})",
-            config.sample_rate_val,
-            f64::from(wav_sample_per_sec) * 0.000_001,
-            if config.wav_params.channels == 1 {
-                "Real"
-            } else {
-                "IQ"
-            }
-        );
+        print_samplerate(config, wav_sample_per_sec);
     }
 
-    match device.partid_serialno() {
-        Ok(partid_serialno) => eprintln!(
-            "Device Serial Number: 0x{:08X}{:08X}",
-            partid_serialno.serial_no[2], partid_serialno.serial_no[3]
-        ),
-        Err(err) => {
-            print_error("airspy_board_partid_serialno_read()", &err);
-            return Err(());
-        }
-    }
+    print_device_serial(&device)?;
 
     if config.call_set_packing
         && let Err(err) = device.set_packing(config.packing)
@@ -595,6 +295,50 @@ fn print_summary(config: &Config, shared: &Mutex<RxShared>, started: Instant) {
     }
 }
 
+/// C writes the placeholder header before streaming (fwrite,
+/// unchecked there; a failure here cannot produce a valid capture).
+fn write_wav_placeholder(config: &Config, shared: &Mutex<RxShared>) -> Result<(), ()> {
+    let mut state = lock_shared(shared);
+    if let Some(writer) = state.writer.as_mut()
+        && writer.write_all(&wav_header_placeholder()).is_err()
+    {
+        eprintln!("Failed to open file: {}", config.path);
+        return Err(());
+    }
+    Ok(())
+}
+
+/// C traps INT/ILL/FPE/SEGV/TERM/ABRT; the ctrlc termination feature
+/// covers the catchable INT/TERM (plus HUP), so a SIGTERM still
+/// finalizes the WAV header.
+fn install_signal_handler() {
+    let handler = ctrlc::set_handler(|| {
+        eprintln!("Caught signal, exiting...");
+        DO_EXIT.store(true, Ordering::SeqCst);
+    });
+    if handler.is_err() {
+        eprintln!("Failed to install signal handler");
+    }
+}
+
+/// Failure cleanup once the output (and possibly the stream) exists:
+/// stop, drop the device, and finalize so a `-w` capture keeps a
+/// valid header. Deviation: C exits from these paths leaving the
+/// placeholder header unwritten.
+fn abort_stream(
+    mut device: Device,
+    config: &Config,
+    shared: &Mutex<RxShared>,
+    wav_sample_per_sec: u32,
+) -> i32 {
+    if let Err(err) = device.stop_rx() {
+        print_error("airspy_stop_rx()", &err);
+    }
+    drop(device);
+    finalize_output(config, shared, wav_sample_per_sec);
+    1
+}
+
 /// The device-facing half of C `main()`: open, configure, stream, and
 /// report, in C's exact order.
 #[allow(clippy::cast_precision_loss)]
@@ -613,29 +357,10 @@ fn run(config: &Config) -> i32 {
         buf: Vec::new(),
     }));
 
-    // C writes the placeholder header before streaming (fwrite,
-    // unchecked there; a failure here cannot produce a valid capture).
-    if config.receive_wav {
-        let mut state = lock_shared(&shared);
-        if let Some(writer) = state.writer.as_mut()
-            && writer.write_all(&wav_header_placeholder()).is_err()
-        {
-            eprintln!("Failed to open file: {}", config.path);
-            return 1;
-        }
+    if config.receive_wav && write_wav_placeholder(config, &shared).is_err() {
+        return 1;
     }
-
-    // C traps INT/ILL/FPE/SEGV/TERM/ABRT; the ctrlc termination
-    // feature covers the catchable INT/TERM (plus HUP), so a SIGTERM
-    // still finalizes the WAV header below.
-    let handler = ctrlc::set_handler(|| {
-        eprintln!("Caught signal, exiting...");
-        DO_EXIT.store(true, Ordering::SeqCst);
-    });
-    if handler.is_err() {
-        eprintln!("Failed to install signal handler");
-    }
-
+    install_signal_handler();
     apply_gains(&device, config);
 
     let started = Instant::now();
@@ -645,7 +370,7 @@ fn run(config: &Config) -> i32 {
         on_transfer(&callback_shared, started, sample_type, packing, &transfer)
     }) {
         print_error("airspy_start_rx()", &err);
-        return 1;
+        return abort_stream(device, config, &shared, wav_sample_per_sec);
     }
 
     // C sets the frequency after starting the stream. On failure C
@@ -654,12 +379,7 @@ fn run(config: &Config) -> i32 {
     // whatever was captured stays readable.
     if let Err(err) = device.set_freq(config.freq_hz) {
         print_error("airspy_set_freq()", &err);
-        if let Err(stop_err) = device.stop_rx() {
-            print_error("airspy_stop_rx()", &stop_err);
-        }
-        drop(device);
-        finalize_output(config, &shared, wav_sample_per_sec);
-        return 1;
+        return abort_stream(device, config, &shared, wav_sample_per_sec);
     }
 
     eprintln!("Stop with Ctrl-C");
@@ -711,112 +431,4 @@ fn rewrite_wav_header(config: &Config, wav_sample_per_sec: u32) -> Result<(), St
     file.seek(SeekFrom::Start(0)).map_err(|_| fail())?;
     file.write_all(&header).map_err(|_| fail())?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn parse(argv: &[&str]) -> Args {
-        Args::try_parse_from(std::iter::once("airspy_rx").chain(argv.iter().copied()))
-            .expect("args parse")
-    }
-
-    #[test]
-    fn args_mirror_c_flags() {
-        let args = parse(&[
-            "-r", "out.bin", "-s", "0x1234", "-p", "1", "-f", "100.5", "-a", "1", "-t", "0", "-b",
-            "1", "-v", "10", "-m", "9", "-l", "8", "-n", "5000", "-d",
-        ]);
-        assert_eq!(args.receive_file.as_deref(), Some("out.bin"));
-        assert_eq!(args.serial_number, Some(0x1234));
-        assert_eq!(args.packing, Some(1));
-        assert_eq!(args.freq_mhz.as_deref(), Some("100.5"));
-        assert_eq!(args.sample_rate, Some(1));
-        assert_eq!(args.sample_type, Some(0));
-        assert_eq!(args.biast, Some(1));
-        assert_eq!(
-            (args.vga_gain, args.mixer_gain, args.lna_gain),
-            (Some(10), Some(9), Some(8))
-        );
-        assert_eq!(args.num_samples, Some(5000));
-        assert!(args.verbose);
-    }
-
-    #[test]
-    fn dash_h_is_sensitivity_gain_not_help() {
-        // C's -h is the sensitivity gain; help moved to --help.
-        let args = parse(&["-r", "f", "-h", "12"]);
-        assert_eq!(args.sensitivity_gain, Some(12));
-    }
-
-    #[test]
-    fn config_defaults_match_c_globals() {
-        let config = build_config(&parse(&["-r", "f"]), "20260101_000000").expect("config");
-        assert_eq!(config.freq_hz, DEFAULT_FREQ_HZ);
-        assert_eq!(config.sample_type, SampleType::Int16Iq);
-        assert_eq!(config.sample_rate_val, 0);
-        assert_eq!(
-            (config.vga_gain, config.mixer_gain, config.lna_gain),
-            (DEFAULT_VGA_IF_GAIN, DEFAULT_MIXER_GAIN, DEFAULT_LNA_GAIN)
-        );
-        assert!(!config.biast);
-        assert!(!config.packing && !config.call_set_packing);
-        assert!(!config.limit_num_samples);
-    }
-
-    #[test]
-    fn validation_rejects_out_of_range_values_in_c_order() {
-        let cases: &[(&[&str], &str)] = &[
-            (&["-r", "f", "-f", "2000"], "frequency_MHz"),
-            (&["-w", "-t", "5"], "RAW sampling mode"),
-            (&[], "you shall specify at least"),
-            (&["-r", "f", "-p", "2"], "packing out of range"),
-            (&["-r", "f", "-t", "6"], "sample_type out of range"),
-            (&["-r", "f", "-b", "2"], "biast_val out of range"),
-            (&["-r", "f", "-v", "16"], "vga_gain out of range"),
-            (&["-r", "f", "-m", "16"], "mixer_gain out of range"),
-            (&["-r", "f", "-l", "15"], "lna_gain out of range"),
-            (&["-r", "f", "-g", "22"], "linearity_gain out of range"),
-            (&["-r", "f", "-h", "22"], "sensitivity_gain out of range"),
-            (&["-r", "f", "-g", "1", "-h", "1"], "both set"),
-        ];
-        for (argv, expected) in cases {
-            let err = build_config(&parse(argv), "20260101_000000").expect_err(expected);
-            assert!(err.contains(expected), "{argv:?}: {err}");
-        }
-    }
-
-    #[test]
-    fn biast_does_not_imply_serial_open() {
-        // Deviation: C's -b case sets the serial_number flag (a
-        // copy-paste bug), silently switching a bare `-b 1` run to
-        // airspy_open_sn(0). Here -b only drives the bias tee.
-        let config =
-            build_config(&parse(&["-r", "f", "-b", "1"]), "20260101_000000").expect("config");
-        assert!(config.biast);
-        assert_eq!(config.serial_number, None);
-    }
-
-    #[test]
-    fn wav_mode_generates_c_filename() {
-        let config = build_config(&parse(&["-w", "-f", "100"]), "20261225_101112").expect("config");
-        assert!(config.receive_wav);
-        assert_eq!(config.path, "AirSpy_20261225_101112Z_100000kHz_IQ.wav");
-    }
-
-    #[test]
-    fn num_samples_limit_computes_byte_budget() {
-        // int16 IQ: 16 bits * 2 channels / 8 = 4 bytes per sample.
-        let config =
-            build_config(&parse(&["-r", "f", "-n", "1000"]), "20260101_000000").expect("config");
-        assert!(config.limit_num_samples);
-        assert_eq!(config.bytes_to_xfer, 4000);
-        let err = build_config(
-            &parse(&["-r", "f", "-n", "0x8000000000000000"]),
-            "20260101_000000",
-        )
-        .expect_err("max");
-        assert!(err.contains("num_samples must be less than"));
-    }
 }

--- a/crates/airspy-tools/src/bin/airspy_rx.rs
+++ b/crates/airspy-tools/src/bin/airspy_rx.rs
@@ -10,10 +10,11 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Instant;
 
 use airspy_tools::rx::{
-    FD_BUFFER_SIZE, RateTracker, WAV_MAX_DATA_BYTES, apply_byte_budget, extend_sample_bytes,
-    frame_count, resolve_display_rate, wav_header_finalized, wav_header_placeholder,
+    FD_BUFFER_SIZE, RateTracker, apply_byte_budget, extend_sample_bytes, frame_count,
+    resolve_display_rate,
 };
 use airspy_tools::rx_cli::{Args, Config, build_config, print_verbose, usage};
+use airspy_tools::wav::{WAV_MAX_DATA_BYTES, wav_header_finalized, wav_header_placeholder};
 use clap::Parser;
 use libairspy_rs::commands::SampleType;
 use libairspy_rs::stream::Transfer;

--- a/crates/airspy-tools/src/bin/airspy_rx.rs
+++ b/crates/airspy-tools/src/bin/airspy_rx.rs
@@ -421,10 +421,11 @@ fn main() {
     std::process::exit(run(&config));
 }
 
-/// The device-facing half of C `main()`: open, configure in C's exact
-/// order, stream, and report — every failure prints C's message.
-#[allow(clippy::too_many_lines, clippy::cast_precision_loss)]
-fn run(config: &Config) -> i32 {
+/// Open the device and apply the pre-stream configuration in C
+/// `main()`'s exact order: sample type, sample-rate resolution and
+/// set, serial-number print, packing, bias-T. Returns the device and
+/// the resolved WAV/display rate; every failure prints C's message.
+fn open_configured_device(config: &Config) -> Result<(Device, u32), ()> {
     let open_result = match config.serial_number {
         Some(serial) => (Device::open_serial(serial), "airspy_open_sn()"),
         None => (Device::open(), "airspy_open()"),
@@ -433,13 +434,13 @@ fn run(config: &Config) -> i32 {
         (Ok(device), _) => device,
         (Err(err), context) => {
             print_error(context, &err);
-            return 1;
+            return Err(());
         }
     };
 
     if let Err(err) = device.set_sample_type(config.sample_type) {
         print_error("airspy_set_sample_type()", &err);
-        return 1;
+        return Err(());
     }
 
     // C: airspy_get_samplerates count + table read, then the index-
@@ -447,12 +448,12 @@ fn run(config: &Config) -> i32 {
     let rates = device.samplerates();
     let Some(wav_sample_per_sec) = resolve_display_rate(config.sample_rate_val, &rates) else {
         eprintln!("argument error: unsupported sample rate");
-        return 1;
+        return Err(());
     };
 
     if let Err(err) = device.set_samplerate(config.sample_rate_val) {
         print_error("airspy_set_samplerate()", &err);
-        return 1;
+        return Err(());
     }
     if config.verbose {
         eprintln!(
@@ -474,7 +475,7 @@ fn run(config: &Config) -> i32 {
         ),
         Err(err) => {
             print_error("airspy_board_partid_serialno_read()", &err);
-            return 1;
+            return Err(());
         }
     }
 
@@ -482,23 +483,126 @@ fn run(config: &Config) -> i32 {
         && let Err(err) = device.set_packing(config.packing)
     {
         print_error("airspy_set_packing()", &err);
-        return 1;
+        return Err(());
     }
 
     if let Err(err) = device.set_rf_bias(config.biast) {
         print_error("airspy_set_rf_bias()", &err);
-        return 1;
+        return Err(());
     }
 
-    let writer: Box<dyn Write + Send> = if config.path == "-" {
-        Box::new(std::io::BufWriter::with_capacity(
+    Ok((device, wav_sample_per_sec))
+}
+
+/// Create the capture output (C's fopen + `setvbuf`; `-` is stdout).
+fn open_output(config: &Config) -> Result<Box<dyn Write + Send>, ()> {
+    if config.path == "-" {
+        return Ok(Box::new(std::io::BufWriter::with_capacity(
             FD_BUFFER_SIZE,
             std::io::stdout(),
-        ))
-    } else if let Ok(file) = std::fs::File::create(&config.path) {
-        Box::new(std::io::BufWriter::with_capacity(FD_BUFFER_SIZE, file))
+        )));
+    }
+    if let Ok(file) = std::fs::File::create(&config.path) {
+        Ok(Box::new(std::io::BufWriter::with_capacity(
+            FD_BUFFER_SIZE,
+            file,
+        )))
     } else {
         eprintln!("Failed to open file: {}", config.path);
+        Err(())
+    }
+}
+
+/// The gain selection before `airspy_start_rx` — C prints failures
+/// but does not abort.
+#[allow(clippy::cast_possible_truncation)]
+fn apply_gains(device: &Device, config: &Config) {
+    if config.linearity_gain.is_none() && config.sensitivity_gain.is_none() {
+        if let Err(err) = device.set_vga_gain(config.vga_gain as u8) {
+            print_error("airspy_set_vga_gain()", &err);
+        }
+        if let Err(err) = device.set_mixer_gain(config.mixer_gain as u8) {
+            print_error("airspy_set_mixer_gain()", &err);
+        }
+        if let Err(err) = device.set_lna_gain(config.lna_gain as u8) {
+            print_error("airspy_set_lna_gain()", &err);
+        }
+    } else {
+        if let Some(gain) = config.linearity_gain
+            && let Err(err) = device.set_linearity_gain(gain as u8)
+        {
+            print_error("airspy_set_linearity_gain()", &err);
+        }
+        if let Some(gain) = config.sensitivity_gain
+            && let Err(err) = device.set_sensitivity_gain(gain as u8)
+        {
+            print_error("airspy_set_sensitivity_gain()", &err);
+        }
+    }
+}
+
+/// The 1 Hz status loop from C `main()`: print the smoothed rate,
+/// and — exactly as C does — flip `do_exit` when the `-n` byte budget
+/// empties (C then reports "User cancel, exiting...", the same as a
+/// signal stop).
+fn stream_loop(device: &Device, shared: &Mutex<RxShared>, config: &Config) {
+    while device.is_streaming() && !DO_EXIT.load(Ordering::SeqCst) {
+        let (average_rate, exhausted) = {
+            let state = lock_shared(shared);
+            (state.tracker.average_rate, state.remaining == Some(0))
+        };
+        eprintln!(
+            "Streaming at {:>5} MSPS",
+            format!("{:.3}", average_rate * 1e-6)
+        );
+        if config.limit_num_samples && exhausted {
+            DO_EXIT.store(true, Ordering::SeqCst);
+        } else {
+            std::thread::sleep(LOOP_SLEEP);
+        }
+    }
+}
+
+/// The exit summary from C `main()`: cancel/exit message, total time
+/// from the first packet, and the windowed average speed.
+#[allow(clippy::cast_precision_loss)]
+fn print_summary(config: &Config, shared: &Mutex<RxShared>, started: Instant) {
+    if DO_EXIT.load(Ordering::SeqCst) {
+        eprintln!("\nUser cancel, exiting...");
+    } else {
+        eprintln!("\nExiting...");
+    }
+
+    let (total_time, global_average_rate, rate_samples) = {
+        let state = lock_shared(shared);
+        (
+            started.elapsed().as_secs_f64() - state.tracker.t_start.unwrap_or(0.0),
+            state.tracker.global_average_rate,
+            state.tracker.rate_samples,
+        )
+    };
+    eprintln!("Total time: {total_time:5.4} s");
+    if rate_samples > 0 {
+        eprintln!(
+            "Average speed {:2.4} MSPS {}",
+            global_average_rate * 1e-6 / rate_samples as f32,
+            if config.wav_params.channels == 2 {
+                "IQ"
+            } else {
+                "Real"
+            }
+        );
+    }
+}
+
+/// The device-facing half of C `main()`: open, configure, stream, and
+/// report, in C's exact order.
+#[allow(clippy::cast_precision_loss)]
+fn run(config: &Config) -> i32 {
+    let Ok((mut device, wav_sample_per_sec)) = open_configured_device(config) else {
+        return 1;
+    };
+    let Ok(writer) = open_output(config) else {
         return 1;
     };
 
@@ -521,8 +625,9 @@ fn run(config: &Config) -> i32 {
         }
     }
 
-    // C traps INT/ILL/FPE/SEGV/TERM/ABRT; only the catchable
-    // INT/TERM pair maps to a safe Rust handler.
+    // C traps INT/ILL/FPE/SEGV/TERM/ABRT; the ctrlc termination
+    // feature covers the catchable INT/TERM (plus HUP), so a SIGTERM
+    // still finalizes the WAV header below.
     let handler = ctrlc::set_handler(|| {
         eprintln!("Caught signal, exiting...");
         DO_EXIT.store(true, Ordering::SeqCst);
@@ -531,35 +636,7 @@ fn run(config: &Config) -> i32 {
         eprintln!("Failed to install signal handler");
     }
 
-    // C: gain failures print but do not abort.
-    if config.linearity_gain.is_none() && config.sensitivity_gain.is_none() {
-        #[allow(clippy::cast_possible_truncation)]
-        {
-            if let Err(err) = device.set_vga_gain(config.vga_gain as u8) {
-                print_error("airspy_set_vga_gain()", &err);
-            }
-            if let Err(err) = device.set_mixer_gain(config.mixer_gain as u8) {
-                print_error("airspy_set_mixer_gain()", &err);
-            }
-            if let Err(err) = device.set_lna_gain(config.lna_gain as u8) {
-                print_error("airspy_set_lna_gain()", &err);
-            }
-        }
-    } else {
-        #[allow(clippy::cast_possible_truncation)]
-        {
-            if let Some(gain) = config.linearity_gain
-                && let Err(err) = device.set_linearity_gain(gain as u8)
-            {
-                print_error("airspy_set_linearity_gain()", &err);
-            }
-            if let Some(gain) = config.sensitivity_gain
-                && let Err(err) = device.set_sensitivity_gain(gain as u8)
-            {
-                print_error("airspy_set_sensitivity_gain()", &err);
-            }
-        }
-    }
+    apply_gains(&device, config);
 
     let started = Instant::now();
     let callback_shared = Arc::clone(&shared);
@@ -571,57 +648,24 @@ fn run(config: &Config) -> i32 {
         return 1;
     }
 
-    // C sets the frequency after starting the stream.
+    // C sets the frequency after starting the stream. On failure C
+    // exits leaving the WAV placeholder header unwritten (an unusable
+    // file); deviation: stop the stream and finalize the output so
+    // whatever was captured stays readable.
     if let Err(err) = device.set_freq(config.freq_hz) {
         print_error("airspy_set_freq()", &err);
+        if let Err(stop_err) = device.stop_rx() {
+            print_error("airspy_stop_rx()", &stop_err);
+        }
+        drop(device);
+        finalize_output(config, &shared, wav_sample_per_sec);
         return 1;
     }
 
     eprintln!("Stop with Ctrl-C");
     std::thread::sleep(LOOP_SLEEP);
-
-    while device.is_streaming() && !DO_EXIT.load(Ordering::SeqCst) {
-        let (average_rate, exhausted) = {
-            let state = lock_shared(&shared);
-            (state.tracker.average_rate, state.remaining == Some(0))
-        };
-        eprintln!(
-            "Streaming at {:>5} MSPS",
-            format!("{:.3}", average_rate * 1e-6)
-        );
-        if config.limit_num_samples && exhausted {
-            DO_EXIT.store(true, Ordering::SeqCst);
-        } else {
-            std::thread::sleep(LOOP_SLEEP);
-        }
-    }
-
-    if DO_EXIT.load(Ordering::SeqCst) {
-        eprintln!("\nUser cancel, exiting...");
-    } else {
-        eprintln!("\nExiting...");
-    }
-
-    let (total_time, global_average_rate, rate_samples) = {
-        let state = lock_shared(&shared);
-        (
-            started.elapsed().as_secs_f64() - state.tracker.t_start.unwrap_or(0.0),
-            state.tracker.global_average_rate,
-            state.tracker.rate_samples,
-        )
-    };
-    eprintln!("Total time: {total_time:5.4} s");
-    if rate_samples > 0 {
-        eprintln!(
-            "Average speed {:2.4} MSPS {}",
-            global_average_rate * 1e-6 / rate_samples as f32,
-            if config.wav_params.channels == 2 {
-                "IQ"
-            } else {
-                "Real"
-            }
-        );
-    }
+    stream_loop(&device, &shared, config);
+    print_summary(config, &shared, started);
 
     if let Err(err) = device.stop_rx() {
         print_error("airspy_stop_rx()", &err);

--- a/crates/airspy-tools/src/bin/airspy_rx.rs
+++ b/crates/airspy-tools/src/bin/airspy_rx.rs
@@ -1,0 +1,778 @@
+//! Port of `airspy_rx.c`: capture samples to a file (or stdout) with
+//! sample-type, rate, frequency, gain, packing, bias-T, and
+//! sample-count controls, plus SDR#-compatible WAV output. Console
+//! output and the runtime sequence track the C tool so the two can be
+//! diffed; deviations from upstream bugs are documented inline.
+
+use std::io::{Seek, SeekFrom, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Instant;
+
+use airspy_tools::parse_u64;
+use airspy_tools::rx::{
+    BIAST_MAX, DEFAULT_FREQ_HZ, DEFAULT_LNA_GAIN, DEFAULT_MIXER_GAIN, DEFAULT_VGA_IF_GAIN,
+    FD_BUFFER_SIZE, FREQ_HZ_MAX, FREQ_HZ_MIN, FREQ_ONE_MHZ, LINEARITY_GAIN_MAX, LNA_GAIN_MAX,
+    MIXER_GAIN_MAX, RateTracker, SAMPLES_TO_XFER_MAX, SENSITIVITY_GAIN_MAX, VGA_GAIN_MAX,
+    WavParams, bytes_to_xfer, extend_sample_bytes, frame_count, parse_freq_mhz, parse_u32,
+    resolve_display_rate, wav_filename, wav_header_finalized, wav_header_placeholder,
+};
+use clap::Parser;
+use libairspy_rs::commands::SampleType;
+use libairspy_rs::stream::Transfer;
+use libairspy_rs::{Device, Error};
+
+/// `AIRSPY_RX_VERSION` in `airspy_rx.c`.
+const AIRSPY_RX_VERSION: &str = "1.0.5 23 April 2016";
+
+/// One second — the C main loop's `sleep(1)` cadence.
+const LOOP_SLEEP: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// `do_exit` in `airspy_rx.c`, flipped by the signal handler.
+static DO_EXIT: AtomicBool = AtomicBool::new(false);
+
+#[derive(Parser)]
+#[command(
+    name = "airspy_rx",
+    about = "Receive Airspy samples into a file",
+    disable_help_flag = true
+)]
+struct Args {
+    /// Receive data into file
+    #[arg(short = 'r', value_name = "filename")]
+    receive_file: Option<String>,
+
+    /// Receive data into file with WAV header and automatic name
+    #[arg(short = 'w')]
+    receive_wav: bool,
+
+    /// Open device with specified 64bits serial number
+    #[arg(short = 's', value_name = "serial_number_64bits", value_parser = parse_u64)]
+    serial_number: Option<u64>,
+
+    /// Set packing for samples: 1=enabled(12bits packed), 0=disabled
+    #[arg(short = 'p', value_name = "packing", value_parser = parse_u32)]
+    packing: Option<u32>,
+
+    /// Set frequency in MHz
+    #[arg(short = 'f', value_name = "frequency_MHz")]
+    freq_mhz: Option<String>,
+
+    /// Set sample rate (index or Hz)
+    #[arg(short = 'a', value_name = "sample_rate", value_parser = parse_u32)]
+    sample_rate: Option<u32>,
+
+    /// Set sample type: 0=`FLOAT32_IQ`, 1=`FLOAT32_REAL`, 2=`INT16_IQ`,
+    /// 3=`INT16_REAL`, 4=`U16_REAL`, 5=RAW
+    #[arg(short = 't', value_name = "sample_type", value_parser = parse_u32)]
+    sample_type: Option<u32>,
+
+    /// Set Bias Tee: 1=enabled, 0=disabled
+    #[arg(short = 'b', value_name = "biast", value_parser = parse_u32)]
+    biast: Option<u32>,
+
+    /// Set VGA/IF gain, 0-15
+    #[arg(short = 'v', value_name = "vga_gain", value_parser = parse_u32)]
+    vga_gain: Option<u32>,
+
+    /// Set Mixer gain, 0-15
+    #[arg(short = 'm', value_name = "mixer_gain", value_parser = parse_u32)]
+    mixer_gain: Option<u32>,
+
+    /// Set LNA gain, 0-14
+    #[arg(short = 'l', value_name = "lna_gain", value_parser = parse_u32)]
+    lna_gain: Option<u32>,
+
+    /// Set linearity simplified gain, 0-21
+    #[arg(short = 'g', value_name = "linearity_gain", value_parser = parse_u32)]
+    linearity_gain: Option<u32>,
+
+    /// Set sensitivity simplified gain, 0-21 (C's -h; use --help for
+    /// this text)
+    #[arg(short = 'h', value_name = "sensitivity_gain", value_parser = parse_u32)]
+    sensitivity_gain: Option<u32>,
+
+    /// Number of samples to transfer (default is unlimited)
+    #[arg(short = 'n', value_name = "num_samples", value_parser = parse_u64)]
+    num_samples: Option<u64>,
+
+    /// Verbose mode
+    #[arg(short = 'd')]
+    verbose: bool,
+
+    /// Print help
+    #[arg(long, action = clap::ArgAction::Help)]
+    help: Option<bool>,
+}
+
+/// The `usage()` text from `airspy_rx.c`, printed after argument
+/// errors.
+fn usage() {
+    eprintln!("airspy_rx v{AIRSPY_RX_VERSION}");
+    eprintln!("Usage:");
+    eprintln!("-r <filename>: Receive data into file");
+    eprintln!("-w Receive data into file with WAV header and automatic name");
+    eprintln!(" This is for SDR# compatibility and may not work with other software");
+    eprintln!("[-s serial_number_64bits]: Open device with specified 64bits serial number");
+    eprintln!("[-p packing]: Set packing for samples, ");
+    eprintln!(" 1=enabled(12bits packed), 0=disabled(default 16bits not packed)");
+    eprintln!(
+        "[-f frequency_MHz]: Set frequency in MHz between [{}, {}] (default {}MHz)",
+        FREQ_HZ_MIN / FREQ_ONE_MHZ,
+        FREQ_HZ_MAX / FREQ_ONE_MHZ,
+        DEFAULT_FREQ_HZ / FREQ_ONE_MHZ
+    );
+    eprintln!("[-a sample_rate]: Set sample rate");
+    eprintln!("[-t sample_type]: Set sample type, ");
+    eprintln!(
+        " 0=FLOAT32_IQ, 1=FLOAT32_REAL, 2=INT16_IQ(default), 3=INT16_REAL, 4=U16_REAL, 5=RAW"
+    );
+    eprintln!("[-b biast]: Set Bias Tee, 1=enabled, 0=disabled(default)");
+    eprintln!("[-v vga_gain]: Set VGA/IF gain, 0-{VGA_GAIN_MAX} (default {DEFAULT_VGA_IF_GAIN})");
+    eprintln!("[-m mixer_gain]: Set Mixer gain, 0-{MIXER_GAIN_MAX} (default {DEFAULT_MIXER_GAIN})");
+    eprintln!("[-l lna_gain]: Set LNA gain, 0-{LNA_GAIN_MAX} (default {DEFAULT_LNA_GAIN})");
+    eprintln!("[-g linearity_gain]: Set linearity simplified gain, 0-{LINEARITY_GAIN_MAX}");
+    eprintln!("[-h sensivity_gain]: Set sensitivity simplified gain, 0-{SENSITIVITY_GAIN_MAX}");
+    eprintln!("[-n num_samples]: Number of samples to transfer (default is unlimited)");
+    eprintln!("[-d]: Verbose mode");
+}
+
+/// The validated capture parameters, C's checked globals after the
+/// argument section of `main()`.
+// The bools mirror the C tool's independent flag globals.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug)]
+struct Config {
+    path: String,
+    receive_wav: bool,
+    serial_number: Option<u64>,
+    packing: bool,
+    call_set_packing: bool,
+    freq_hz: u32,
+    sample_rate_val: u32,
+    sample_type: SampleType,
+    wav_params: WavParams,
+    biast: bool,
+    vga_gain: u32,
+    mixer_gain: u32,
+    lna_gain: u32,
+    linearity_gain: Option<u32>,
+    sensitivity_gain: Option<u32>,
+    limit_num_samples: bool,
+    samples_to_xfer: u64,
+    bytes_to_xfer: u64,
+    verbose: bool,
+}
+
+/// The `-t` value → sample type mapping from the C switch (`None` is
+/// the out-of-range marker checked later).
+fn sample_type_from_u32(value: u32) -> Option<SampleType> {
+    match value {
+        0 => Some(SampleType::Float32Iq),
+        1 => Some(SampleType::Float32Real),
+        2 => Some(SampleType::Int16Iq),
+        3 => Some(SampleType::Int16Real),
+        4 => Some(SampleType::Uint16Real),
+        5 => Some(SampleType::Raw),
+        _ => None,
+    }
+}
+
+/// Every post-getopt validation from `airspy_rx.c` `main()`, in C's order
+/// and with C's stderr messages. `date_time` is the pre-formatted
+/// `%Y%m%d_%H%M%S` local time for the `-w` automatic filename.
+///
+/// Deviation: C's `-b` case sets the *`serial_number`* flag instead of
+/// a bias-T flag (a copy-paste bug that makes a bare `-b 1` open
+/// serial number 0); here `-b` only controls the bias tee.
+#[allow(clippy::too_many_lines)]
+fn build_config(args: &Args, date_time: &str) -> Result<Config, String> {
+    let sample_type = match args.sample_type {
+        None => Some(SampleType::Int16Iq),
+        Some(v) => sample_type_from_u32(v),
+    };
+    // The WAV parameters fall back to the int16 defaults while the
+    // sample type is invalid, exactly as C's globals do; the
+    // sample_type range check below fires before they are used.
+    let wav_params = WavParams::for_sample_type(sample_type.unwrap_or(SampleType::Int16Iq));
+
+    let samples_to_xfer = args.num_samples.unwrap_or(0);
+    let effective_type = sample_type.unwrap_or(SampleType::Int16Iq);
+    let packing = args.packing == Some(1);
+    let bytes = bytes_to_xfer(samples_to_xfer, &wav_params, effective_type, packing);
+
+    if samples_to_xfer >= SAMPLES_TO_XFER_MAX {
+        return Err(format!(
+            "argument error: num_samples must be less than {SAMPLES_TO_XFER_MAX}/{}Mio",
+            SAMPLES_TO_XFER_MAX / u64::from(FREQ_ONE_MHZ)
+        ));
+    }
+
+    let freq_hz = match &args.freq_mhz {
+        Some(s) => {
+            let hz = parse_freq_mhz(s);
+            if !(FREQ_HZ_MIN..FREQ_HZ_MAX).contains(&hz) {
+                return Err(format!(
+                    "argument error: frequency_MHz={:.6} MHz and shall be between [{}, {}[ MHz",
+                    f64::from(hz) / f64::from(FREQ_ONE_MHZ),
+                    FREQ_HZ_MIN / FREQ_ONE_MHZ,
+                    FREQ_HZ_MAX / FREQ_ONE_MHZ
+                ));
+            }
+            hz
+        }
+        None => DEFAULT_FREQ_HZ,
+    };
+
+    let path = if args.receive_wav {
+        if sample_type == Some(SampleType::Raw) {
+            return Err("The RAW sampling mode is not compatible with Wave files".into());
+        }
+        wav_filename(date_time, freq_hz)
+    } else {
+        match &args.receive_file {
+            Some(p) => p.clone(),
+            None => {
+                return Err(
+                    "error: you shall specify at least -r <with filename> or -w option".into(),
+                );
+            }
+        }
+    };
+
+    if let Some(p) = args.packing
+        && p > 1
+    {
+        return Err("argument error: packing out of range".into());
+    }
+    let Some(sample_type) = sample_type else {
+        return Err("argument error: sample_type out of range".into());
+    };
+    let biast_val = args.biast.unwrap_or(0);
+    if biast_val > BIAST_MAX {
+        return Err("argument error: biast_val out of range".into());
+    }
+    let vga_gain = args.vga_gain.unwrap_or(DEFAULT_VGA_IF_GAIN);
+    if vga_gain > VGA_GAIN_MAX {
+        return Err("argument error: vga_gain out of range".into());
+    }
+    let mixer_gain = args.mixer_gain.unwrap_or(DEFAULT_MIXER_GAIN);
+    if mixer_gain > MIXER_GAIN_MAX {
+        return Err("argument error: mixer_gain out of range".into());
+    }
+    let lna_gain = args.lna_gain.unwrap_or(DEFAULT_LNA_GAIN);
+    if lna_gain > LNA_GAIN_MAX {
+        return Err("argument error: lna_gain out of range".into());
+    }
+    if args.linearity_gain.unwrap_or(0) > LINEARITY_GAIN_MAX {
+        return Err("argument error: linearity_gain out of range".into());
+    }
+    if args.sensitivity_gain.unwrap_or(0) > SENSITIVITY_GAIN_MAX {
+        return Err("argument error: sensitivity_gain out of range".into());
+    }
+    if args.linearity_gain.is_some() && args.sensitivity_gain.is_some() {
+        return Err(
+            "argument error: linearity_gain and sensitivity_gain are both set (choose only one option)"
+                .into(),
+        );
+    }
+
+    Ok(Config {
+        path,
+        receive_wav: args.receive_wav,
+        serial_number: args.serial_number,
+        packing,
+        call_set_packing: args.packing.is_some(),
+        freq_hz,
+        sample_rate_val: args.sample_rate.unwrap_or(0),
+        sample_type,
+        wav_params,
+        biast: biast_val == 1,
+        vga_gain,
+        mixer_gain,
+        lna_gain,
+        linearity_gain: args.linearity_gain,
+        sensitivity_gain: args.sensitivity_gain,
+        limit_num_samples: args.num_samples.is_some(),
+        samples_to_xfer,
+        bytes_to_xfer: bytes,
+        verbose: args.verbose,
+    })
+}
+
+/// The `if (verbose)` argument dump in `airspy_rx.c` `main()`.
+fn print_verbose(config: &Config) {
+    eprintln!("airspy_rx v{AIRSPY_RX_VERSION}");
+    if let Some(serial) = config.serial_number {
+        eprintln!(
+            "serial_number_64bits -s 0x{:08X}{:08X}",
+            (serial >> 32) as u32,
+            (serial & 0xFFFF_FFFF) as u32
+        );
+    }
+    eprintln!("packing -p {}", u32::from(config.packing));
+    eprintln!(
+        "frequency_MHz -f {:.6}MHz ({}Hz)",
+        f64::from(config.freq_hz) / f64::from(FREQ_ONE_MHZ),
+        config.freq_hz
+    );
+    eprintln!("sample_type -t {}", config.sample_type as u8);
+    eprintln!("biast -b {}", u32::from(config.biast));
+    if config.linearity_gain.is_none() && config.sensitivity_gain.is_none() {
+        eprintln!("vga_gain -v {}", config.vga_gain);
+        eprintln!("mixer_gain -m {}", config.mixer_gain);
+        eprintln!("lna_gain -l {}", config.lna_gain);
+    } else {
+        if let Some(g) = config.linearity_gain {
+            eprintln!("linearity_gain -g {g}");
+        }
+        if let Some(g) = config.sensitivity_gain {
+            eprintln!("sensitivity_gain -h {g}");
+        }
+    }
+    if config.limit_num_samples {
+        eprintln!(
+            "num_samples -n {} ({}M)",
+            config.samples_to_xfer,
+            config.samples_to_xfer / u64::from(FREQ_ONE_MHZ)
+        );
+    }
+}
+
+/// `context() failed: name (code)` — the C error-print pattern.
+fn print_error(context: &str, err: &Error) {
+    eprintln!("{context} failed: {} ({})", err.name(), err.code());
+}
+
+/// The callback-side state shared with the main loop — C's globals
+/// (`fd`, the rate bookkeeping, `bytes_to_xfer`).
+struct RxShared {
+    writer: Option<Box<dyn Write + Send>>,
+    tracker: RateTracker,
+    /// Remaining byte budget when `-n` was given.
+    remaining: Option<u64>,
+    /// Reused per-block byte buffer.
+    buf: Vec<u8>,
+}
+
+/// Lock the shared state, recovering from a poisoned mutex (a panic
+/// on the consumer thread already stops the stream).
+fn lock_shared(shared: &Mutex<RxShared>) -> MutexGuard<'_, RxShared> {
+    match shared.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+/// `rx_callback` in `airspy_rx.c`: track the rate, honor the `-n` byte
+/// budget, and write the block; returning `false` is C's `-1` stop.
+fn on_transfer(
+    shared: &Mutex<RxShared>,
+    started: Instant,
+    sample_type: SampleType,
+    packing: bool,
+    transfer: &Transfer<'_>,
+) -> bool {
+    let mut state = lock_shared(shared);
+    let state = &mut *state;
+    let frames = frame_count(&transfer.samples, sample_type, packing);
+    state
+        .tracker
+        .on_block(frames, started.elapsed().as_secs_f64());
+
+    state.buf.clear();
+    extend_sample_bytes(&mut state.buf, &transfer.samples);
+    let mut bytes_to_write = state.buf.len();
+    if let Some(remaining) = state.remaining.as_mut() {
+        #[allow(clippy::cast_possible_truncation)]
+        if bytes_to_write as u64 >= *remaining {
+            bytes_to_write = *remaining as usize;
+        }
+        *remaining -= bytes_to_write as u64;
+    }
+
+    let Some(writer) = state.writer.as_mut() else {
+        return false;
+    };
+    if writer.write_all(&state.buf[..bytes_to_write]).is_err() {
+        return false;
+    }
+    // C: stop once the byte budget is exhausted.
+    state.remaining != Some(0)
+}
+
+fn main() {
+    let args = Args::parse();
+    let date_time = chrono::Local::now().format("%Y%m%d_%H%M%S").to_string();
+    let config = match build_config(&args, &date_time) {
+        Ok(config) => config,
+        Err(message) => {
+            eprintln!("{message}");
+            usage();
+            std::process::exit(1);
+        }
+    };
+    if config.receive_wav {
+        eprintln!("Receive wav file: {}", config.path);
+    }
+    if config.verbose {
+        print_verbose(&config);
+    }
+    std::process::exit(run(&config));
+}
+
+/// The device-facing half of C `main()`: open, configure in C's exact
+/// order, stream, and report — every failure prints C's message.
+#[allow(clippy::too_many_lines, clippy::cast_precision_loss)]
+fn run(config: &Config) -> i32 {
+    let open_result = match config.serial_number {
+        Some(serial) => (Device::open_serial(serial), "airspy_open_sn()"),
+        None => (Device::open(), "airspy_open()"),
+    };
+    let mut device = match open_result {
+        (Ok(device), _) => device,
+        (Err(err), context) => {
+            print_error(context, &err);
+            return 1;
+        }
+    };
+
+    if let Err(err) = device.set_sample_type(config.sample_type) {
+        print_error("airspy_set_sample_type()", &err);
+        return 1;
+    }
+
+    // C: airspy_get_samplerates count + table read, then the index-
+    // or-literal resolution for the WAV/display rate.
+    let rates = device.samplerates();
+    let Some(wav_sample_per_sec) = resolve_display_rate(config.sample_rate_val, &rates) else {
+        eprintln!("argument error: unsupported sample rate");
+        return 1;
+    };
+
+    if let Err(err) = device.set_samplerate(config.sample_rate_val) {
+        print_error("airspy_set_samplerate()", &err);
+        return 1;
+    }
+    if config.verbose {
+        eprintln!(
+            "sample_rate -a {} ({:.6} MSPS {})",
+            config.sample_rate_val,
+            f64::from(wav_sample_per_sec) * 0.000_001,
+            if config.wav_params.channels == 1 {
+                "Real"
+            } else {
+                "IQ"
+            }
+        );
+    }
+
+    match device.partid_serialno() {
+        Ok(partid_serialno) => eprintln!(
+            "Device Serial Number: 0x{:08X}{:08X}",
+            partid_serialno.serial_no[2], partid_serialno.serial_no[3]
+        ),
+        Err(err) => {
+            print_error("airspy_board_partid_serialno_read()", &err);
+            return 1;
+        }
+    }
+
+    if config.call_set_packing
+        && let Err(err) = device.set_packing(config.packing)
+    {
+        print_error("airspy_set_packing()", &err);
+        return 1;
+    }
+
+    if let Err(err) = device.set_rf_bias(config.biast) {
+        print_error("airspy_set_rf_bias()", &err);
+        return 1;
+    }
+
+    let writer: Box<dyn Write + Send> = if config.path == "-" {
+        Box::new(std::io::BufWriter::with_capacity(
+            FD_BUFFER_SIZE,
+            std::io::stdout(),
+        ))
+    } else if let Ok(file) = std::fs::File::create(&config.path) {
+        Box::new(std::io::BufWriter::with_capacity(FD_BUFFER_SIZE, file))
+    } else {
+        eprintln!("Failed to open file: {}", config.path);
+        return 1;
+    };
+
+    let shared = Arc::new(Mutex::new(RxShared {
+        writer: Some(writer),
+        tracker: RateTracker::new(wav_sample_per_sec as f32),
+        remaining: config.limit_num_samples.then_some(config.bytes_to_xfer),
+        buf: Vec::new(),
+    }));
+
+    // C writes the placeholder header before streaming (fwrite,
+    // unchecked there; a failure here cannot produce a valid capture).
+    if config.receive_wav {
+        let mut state = lock_shared(&shared);
+        if let Some(writer) = state.writer.as_mut()
+            && writer.write_all(&wav_header_placeholder()).is_err()
+        {
+            eprintln!("Failed to open file: {}", config.path);
+            return 1;
+        }
+    }
+
+    // C traps INT/ILL/FPE/SEGV/TERM/ABRT; only the catchable
+    // INT/TERM pair maps to a safe Rust handler.
+    let handler = ctrlc::set_handler(|| {
+        eprintln!("Caught signal, exiting...");
+        DO_EXIT.store(true, Ordering::SeqCst);
+    });
+    if handler.is_err() {
+        eprintln!("Failed to install signal handler");
+    }
+
+    // C: gain failures print but do not abort.
+    if config.linearity_gain.is_none() && config.sensitivity_gain.is_none() {
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            if let Err(err) = device.set_vga_gain(config.vga_gain as u8) {
+                print_error("airspy_set_vga_gain()", &err);
+            }
+            if let Err(err) = device.set_mixer_gain(config.mixer_gain as u8) {
+                print_error("airspy_set_mixer_gain()", &err);
+            }
+            if let Err(err) = device.set_lna_gain(config.lna_gain as u8) {
+                print_error("airspy_set_lna_gain()", &err);
+            }
+        }
+    } else {
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            if let Some(gain) = config.linearity_gain
+                && let Err(err) = device.set_linearity_gain(gain as u8)
+            {
+                print_error("airspy_set_linearity_gain()", &err);
+            }
+            if let Some(gain) = config.sensitivity_gain
+                && let Err(err) = device.set_sensitivity_gain(gain as u8)
+            {
+                print_error("airspy_set_sensitivity_gain()", &err);
+            }
+        }
+    }
+
+    let started = Instant::now();
+    let callback_shared = Arc::clone(&shared);
+    let (sample_type, packing) = (config.sample_type, config.packing);
+    if let Err(err) = device.start_rx(move |transfer| {
+        on_transfer(&callback_shared, started, sample_type, packing, &transfer)
+    }) {
+        print_error("airspy_start_rx()", &err);
+        return 1;
+    }
+
+    // C sets the frequency after starting the stream.
+    if let Err(err) = device.set_freq(config.freq_hz) {
+        print_error("airspy_set_freq()", &err);
+        return 1;
+    }
+
+    eprintln!("Stop with Ctrl-C");
+    std::thread::sleep(LOOP_SLEEP);
+
+    while device.is_streaming() && !DO_EXIT.load(Ordering::SeqCst) {
+        let (average_rate, exhausted) = {
+            let state = lock_shared(&shared);
+            (state.tracker.average_rate, state.remaining == Some(0))
+        };
+        eprintln!(
+            "Streaming at {:>5} MSPS",
+            format!("{:.3}", average_rate * 1e-6)
+        );
+        if config.limit_num_samples && exhausted {
+            DO_EXIT.store(true, Ordering::SeqCst);
+        } else {
+            std::thread::sleep(LOOP_SLEEP);
+        }
+    }
+
+    if DO_EXIT.load(Ordering::SeqCst) {
+        eprintln!("\nUser cancel, exiting...");
+    } else {
+        eprintln!("\nExiting...");
+    }
+
+    let (total_time, global_average_rate, rate_samples) = {
+        let state = lock_shared(&shared);
+        (
+            started.elapsed().as_secs_f64() - state.tracker.t_start.unwrap_or(0.0),
+            state.tracker.global_average_rate,
+            state.tracker.rate_samples,
+        )
+    };
+    eprintln!("Total time: {total_time:5.4} s");
+    if rate_samples > 0 {
+        eprintln!(
+            "Average speed {:2.4} MSPS {}",
+            global_average_rate * 1e-6 / rate_samples as f32,
+            if config.wav_params.channels == 2 {
+                "IQ"
+            } else {
+                "Real"
+            }
+        );
+    }
+
+    if let Err(err) = device.stop_rx() {
+        print_error("airspy_stop_rx()", &err);
+    }
+    drop(device);
+
+    finalize_output(config, &shared, wav_sample_per_sec);
+    eprintln!("done");
+    0
+}
+
+/// The end-of-main file handling: flush and close the stream, then
+/// for WAV captures rewrite the header with the real sizes (C's
+/// `ftell` + rewind + `fwrite`).
+fn finalize_output(config: &Config, shared: &Mutex<RxShared>, wav_sample_per_sec: u32) {
+    let writer = lock_shared(shared).writer.take();
+    if let Some(mut writer) = writer
+        && writer.flush().is_err()
+    {
+        eprintln!("Failed to write file: {}", config.path);
+    }
+
+    if config.receive_wav
+        && let Err(message) = rewrite_wav_header(config, wav_sample_per_sec)
+    {
+        eprintln!("{message}");
+    }
+}
+
+/// Reopen the finished capture and overwrite the 44-byte header. C
+/// stores `ftell`'s position in a `uint32_t`, so files past 4 GiB wrap
+/// the size fields (a WAV format limit); the truncating cast keeps
+/// that behavior.
+#[allow(clippy::cast_possible_truncation)]
+fn rewrite_wav_header(config: &Config, wav_sample_per_sec: u32) -> Result<(), String> {
+    let fail = || format!("Failed to write file: {}", config.path);
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&config.path)
+        .map_err(|_| fail())?;
+    let file_pos = file.metadata().map_err(|_| fail())?.len() as u32;
+    let header = wav_header_finalized(file_pos, &config.wav_params, wav_sample_per_sec);
+    file.seek(SeekFrom::Start(0)).map_err(|_| fail())?;
+    file.write_all(&header).map_err(|_| fail())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(argv: &[&str]) -> Args {
+        Args::try_parse_from(std::iter::once("airspy_rx").chain(argv.iter().copied()))
+            .expect("args parse")
+    }
+
+    #[test]
+    fn args_mirror_c_flags() {
+        let args = parse(&[
+            "-r", "out.bin", "-s", "0x1234", "-p", "1", "-f", "100.5", "-a", "1", "-t", "0", "-b",
+            "1", "-v", "10", "-m", "9", "-l", "8", "-n", "5000", "-d",
+        ]);
+        assert_eq!(args.receive_file.as_deref(), Some("out.bin"));
+        assert_eq!(args.serial_number, Some(0x1234));
+        assert_eq!(args.packing, Some(1));
+        assert_eq!(args.freq_mhz.as_deref(), Some("100.5"));
+        assert_eq!(args.sample_rate, Some(1));
+        assert_eq!(args.sample_type, Some(0));
+        assert_eq!(args.biast, Some(1));
+        assert_eq!(
+            (args.vga_gain, args.mixer_gain, args.lna_gain),
+            (Some(10), Some(9), Some(8))
+        );
+        assert_eq!(args.num_samples, Some(5000));
+        assert!(args.verbose);
+    }
+
+    #[test]
+    fn dash_h_is_sensitivity_gain_not_help() {
+        // C's -h is the sensitivity gain; help moved to --help.
+        let args = parse(&["-r", "f", "-h", "12"]);
+        assert_eq!(args.sensitivity_gain, Some(12));
+    }
+
+    #[test]
+    fn config_defaults_match_c_globals() {
+        let config = build_config(&parse(&["-r", "f"]), "20260101_000000").expect("config");
+        assert_eq!(config.freq_hz, DEFAULT_FREQ_HZ);
+        assert_eq!(config.sample_type, SampleType::Int16Iq);
+        assert_eq!(config.sample_rate_val, 0);
+        assert_eq!(
+            (config.vga_gain, config.mixer_gain, config.lna_gain),
+            (DEFAULT_VGA_IF_GAIN, DEFAULT_MIXER_GAIN, DEFAULT_LNA_GAIN)
+        );
+        assert!(!config.biast);
+        assert!(!config.packing && !config.call_set_packing);
+        assert!(!config.limit_num_samples);
+    }
+
+    #[test]
+    fn validation_rejects_out_of_range_values_in_c_order() {
+        let cases: &[(&[&str], &str)] = &[
+            (&["-r", "f", "-f", "2000"], "frequency_MHz"),
+            (&["-w", "-t", "5"], "RAW sampling mode"),
+            (&[], "you shall specify at least"),
+            (&["-r", "f", "-p", "2"], "packing out of range"),
+            (&["-r", "f", "-t", "6"], "sample_type out of range"),
+            (&["-r", "f", "-b", "2"], "biast_val out of range"),
+            (&["-r", "f", "-v", "16"], "vga_gain out of range"),
+            (&["-r", "f", "-m", "16"], "mixer_gain out of range"),
+            (&["-r", "f", "-l", "15"], "lna_gain out of range"),
+            (&["-r", "f", "-g", "22"], "linearity_gain out of range"),
+            (&["-r", "f", "-h", "22"], "sensitivity_gain out of range"),
+            (&["-r", "f", "-g", "1", "-h", "1"], "both set"),
+        ];
+        for (argv, expected) in cases {
+            let err = build_config(&parse(argv), "20260101_000000").expect_err(expected);
+            assert!(err.contains(expected), "{argv:?}: {err}");
+        }
+    }
+
+    #[test]
+    fn biast_does_not_imply_serial_open() {
+        // Deviation: C's -b case sets the serial_number flag (a
+        // copy-paste bug), silently switching a bare `-b 1` run to
+        // airspy_open_sn(0). Here -b only drives the bias tee.
+        let config =
+            build_config(&parse(&["-r", "f", "-b", "1"]), "20260101_000000").expect("config");
+        assert!(config.biast);
+        assert_eq!(config.serial_number, None);
+    }
+
+    #[test]
+    fn wav_mode_generates_c_filename() {
+        let config = build_config(&parse(&["-w", "-f", "100"]), "20261225_101112").expect("config");
+        assert!(config.receive_wav);
+        assert_eq!(config.path, "AirSpy_20261225_101112Z_100000kHz_IQ.wav");
+    }
+
+    #[test]
+    fn num_samples_limit_computes_byte_budget() {
+        // int16 IQ: 16 bits * 2 channels / 8 = 4 bytes per sample.
+        let config =
+            build_config(&parse(&["-r", "f", "-n", "1000"]), "20260101_000000").expect("config");
+        assert!(config.limit_num_samples);
+        assert_eq!(config.bytes_to_xfer, 4000);
+        let err = build_config(
+            &parse(&["-r", "f", "-n", "0x8000000000000000"]),
+            "20260101_000000",
+        )
+        .expect_err("max");
+        assert!(err.contains("num_samples must be less than"));
+    }
+}

--- a/crates/airspy-tools/src/bin/airspy_rx.rs
+++ b/crates/airspy-tools/src/bin/airspy_rx.rs
@@ -10,8 +10,8 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Instant;
 
 use airspy_tools::rx::{
-    FD_BUFFER_SIZE, RateTracker, WAV_MAX_DATA_BYTES, extend_sample_bytes, frame_count,
-    resolve_display_rate, wav_header_finalized, wav_header_placeholder,
+    FD_BUFFER_SIZE, RateTracker, WAV_MAX_DATA_BYTES, apply_byte_budget, extend_sample_bytes,
+    frame_count, resolve_display_rate, wav_header_finalized, wav_header_placeholder,
 };
 use airspy_tools::rx_cli::{Args, Config, build_config, print_verbose, usage};
 use clap::Parser;
@@ -76,14 +76,7 @@ fn on_transfer(
 
     state.buf.clear();
     extend_sample_bytes(&mut state.buf, &transfer.samples);
-    let mut bytes_to_write = state.buf.len();
-    if let Some(remaining) = state.remaining.as_mut() {
-        #[allow(clippy::cast_possible_truncation)]
-        if bytes_to_write as u64 >= *remaining {
-            bytes_to_write = *remaining as usize;
-        }
-        *remaining -= bytes_to_write as u64;
-    }
+    let bytes_to_write = apply_byte_budget(&mut state.remaining, state.buf.len());
 
     let Some(writer) = state.writer.as_mut() else {
         return false;

--- a/crates/airspy-tools/src/lib.rs
+++ b/crates/airspy-tools/src/lib.rs
@@ -6,6 +6,7 @@
 #![warn(missing_docs)]
 
 pub mod rx;
+pub mod rx_cli;
 
 /// Failure to parse a `parse_u64`-style argument
 /// (C returns `AIRSPY_ERROR_INVALID_PARAM`).

--- a/crates/airspy-tools/src/lib.rs
+++ b/crates/airspy-tools/src/lib.rs
@@ -5,6 +5,8 @@
 //! holds the argument-parsing and output-formatting code they share.
 #![warn(missing_docs)]
 
+pub mod rx;
+
 /// Failure to parse a `parse_u64`-style argument
 /// (C returns `AIRSPY_ERROR_INVALID_PARAM`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/airspy-tools/src/lib.rs
+++ b/crates/airspy-tools/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod rx;
 pub mod rx_cli;
+pub mod wav;
 
 /// Failure to parse a `parse_u64`-style argument
 /// (C returns `AIRSPY_ERROR_INVALID_PARAM`).

--- a/crates/airspy-tools/src/rx.rs
+++ b/crates/airspy-tools/src/rx.rs
@@ -61,27 +61,39 @@ pub fn parse_u32(s: &str) -> Result<u32, ParseU64Error> {
     parse_u64(s).map(|v| v as u32)
 }
 
-/// C99's `0x` significand with an optional `p`/`P` binary exponent
-/// (`strtod` accepts e.g. `0x1p10` = 1024.0 and `0x1A` = 26.0):
-/// accumulate the hex digits around the optional point, then scale by
-/// `2^(exponent - 4 * fraction digits)`. `None` when no hex digit
-/// follows the prefix — strtod's longest match is then the bare `0`.
-fn hex_float_prefix(bytes: &[u8]) -> Option<f64> {
+/// Accumulate a hex significand (digits around an optional point).
+/// Returns `(mantissa, scale, consumed)` where `scale` is a binary
+/// exponent correction: digits beyond f64 precision shift the scale
+/// up instead of overflowing the mantissa, and fraction digits shift
+/// it down — so a long token like `0x1` + 300 zeros + `p-1193` keeps
+/// its value (128.0) instead of degenerating to `inf * 0 = NaN`.
+/// `None` when no hex digit is present (strtod's no-conversion case).
+fn hex_significand(bytes: &[u8]) -> Option<(f64, i32, usize)> {
+    /// Beyond 2^52 another hex digit no longer fits f64's mantissa.
+    const MANTISSA_CAP: f64 = 4_503_599_627_370_496.0; // 2^52
     let mut mantissa = 0.0f64;
+    let mut scale = 0i32;
     let mut digits = 0usize;
-    let mut frac_digits = 0i32;
     let mut pos = 0usize;
     while let Some(d) = bytes.get(pos).and_then(|b| char::from(*b).to_digit(16)) {
-        mantissa = mantissa * 16.0 + f64::from(d);
+        if mantissa < MANTISSA_CAP {
+            mantissa = mantissa * 16.0 + f64::from(d);
+        } else {
+            // The digit is below f64 precision; keep its place value.
+            scale = scale.saturating_add(4);
+        }
         digits += 1;
         pos += 1;
     }
     if bytes.get(pos) == Some(&b'.') {
         let mut after = pos + 1;
         while let Some(d) = bytes.get(after).and_then(|b| char::from(*b).to_digit(16)) {
-            mantissa = mantissa * 16.0 + f64::from(d);
+            if mantissa < MANTISSA_CAP {
+                mantissa = mantissa * 16.0 + f64::from(d);
+                scale = scale.saturating_sub(4);
+            }
+            // Fraction digits beyond precision are below one ulp.
             digits += 1;
-            frac_digits += 1;
             after += 1;
         }
         // The point joins the token only when digits exist at all
@@ -90,40 +102,54 @@ fn hex_float_prefix(bytes: &[u8]) -> Option<f64> {
             pos = after;
         }
     }
-    if digits == 0 {
-        return None;
+    (digits > 0).then_some((mantissa, scale, pos))
+}
+
+/// The optional `p`/`P` binary-exponent suffix; returns the exponent,
+/// or 0 when `p` is absent or followed by no digit (longest match —
+/// a bare `p` is not part of the token).
+fn binary_exponent(bytes: &[u8]) -> i32 {
+    if !matches!(bytes.first(), Some(b'p' | b'P')) {
+        return 0;
     }
-    let mut exponent = 0i32;
-    if matches!(bytes.get(pos), Some(b'p' | b'P')) {
-        let mut exp_pos = pos + 1;
-        let negative_exp = match bytes.get(exp_pos) {
-            Some(b'-') => {
-                exp_pos += 1;
-                true
-            }
-            Some(b'+') => {
-                exp_pos += 1;
-                false
-            }
-            _ => false,
-        };
-        let mut exp_digits = 0usize;
-        let mut value = 0i32;
-        while let Some(d) = bytes.get(exp_pos).and_then(|b| char::from(*b).to_digit(10)) {
-            // Saturating: powi over/underflows to inf/0 exactly as
-            // strtod does for out-of-range exponents.
-            #[allow(clippy::cast_possible_wrap)]
-            let d = d as i32;
-            value = value.saturating_mul(10).saturating_add(d);
-            exp_digits += 1;
-            exp_pos += 1;
+    let mut pos = 1;
+    let negative = match bytes.get(pos) {
+        Some(b'-') => {
+            pos += 1;
+            true
         }
-        // `p` with no digit is not part of the token (longest match).
-        if exp_digits > 0 {
-            exponent = if negative_exp { -value } else { value };
+        Some(b'+') => {
+            pos += 1;
+            false
         }
+        _ => false,
+    };
+    let mut exp_digits = 0usize;
+    let mut value = 0i32;
+    while let Some(d) = bytes.get(pos).and_then(|b| char::from(*b).to_digit(10)) {
+        // Saturating: powi over/underflows to inf/0 exactly as strtod
+        // does for out-of-range exponents.
+        #[allow(clippy::cast_possible_wrap)]
+        let d = d as i32;
+        value = value.saturating_mul(10).saturating_add(d);
+        exp_digits += 1;
+        pos += 1;
     }
-    Some(mantissa * 2.0f64.powi(exponent.saturating_sub(frac_digits.saturating_mul(4))))
+    if exp_digits == 0 {
+        return 0;
+    }
+    if negative { -value } else { value }
+}
+
+/// C99's `0x` significand with an optional `p`/`P` binary exponent
+/// (`strtod` accepts e.g. `0x1p10` = 1024.0 and `0x1A` = 26.0):
+/// the significand's scale correction and the exponent combine into
+/// one `powi`. `None` when no hex digit follows the prefix —
+/// strtod's longest match is then the bare `0`.
+fn hex_float_prefix(bytes: &[u8]) -> Option<f64> {
+    let (mantissa, scale, consumed) = hex_significand(bytes)?;
+    let exponent = binary_exponent(&bytes[consumed..]);
+    Some(mantissa * 2.0f64.powi(exponent.saturating_add(scale)))
 }
 
 /// `strtod(s, NULL)`'s longest-valid-prefix parse over the forms the
@@ -451,6 +477,15 @@ mod tests {
         // Out-of-range binary exponents saturate like strtod's
         // overflow (rejected by the caller's range check either way).
         assert_eq!(parse_freq_mhz("0x1p99999"), u32::MAX);
+        // A long significand must not overflow before the exponent
+        // applies: 0x1 followed by 300 zeros with p-1193 is exactly
+        // 2^(1200 - 1193) = 128.0, i.e. a valid 128 MHz.
+        let long = format!("0x1{}p-1193", "0".repeat(300));
+        assert_eq!(parse_freq_mhz(&long), 128_000_000);
+        // The same shifting on the fraction side: a long fraction
+        // tail below precision does not disturb the value.
+        let frac = format!("0x1.{}p3", "0".repeat(300));
+        assert_eq!(parse_freq_mhz(&frac), 8_000_000);
     }
 
     #[test]

--- a/crates/airspy-tools/src/rx.rs
+++ b/crates/airspy-tools/src/rx.rs
@@ -47,6 +47,13 @@ pub const FD_BUFFER_SIZE: usize = 16 * 1024;
 /// chunk + 8-byte data-chunk header, no padding.
 pub const WAV_HEADER_LEN: usize = 44;
 
+/// The most data bytes a classic RIFF/WAV file can carry: the 32-bit
+/// size fields cap the whole file at `u32::MAX` bytes, header
+/// included. C wraps its `uint32_t` `ftell` position past 4 GiB and
+/// writes corrupt size fields; deviation: `-w` captures stop at this
+/// budget so the finalized header is always representable.
+pub const WAV_MAX_DATA_BYTES: u64 = u32::MAX as u64 - WAV_HEADER_LEN as u64;
+
 /// The per-buffer window of the C rate average (`buffer_count == 50`
 /// in `rx_callback`).
 const RATE_WINDOW_BUFFERS: u32 = 50;
@@ -447,6 +454,21 @@ mod tests {
         // RAW: 12 bits, mono (the case 5 branch sets only these two).
         let raw = WavParams::for_sample_type(SampleType::Raw);
         assert_eq!((raw.channels, raw.bits_per_sample), (1, 12));
+    }
+
+    #[test]
+    fn wav_data_budget_keeps_sizes_representable() {
+        // A maximal capture finalizes to file_pos = u32::MAX with
+        // in-range RIFF and data sizes.
+        assert_eq!(
+            WAV_MAX_DATA_BYTES + WAV_HEADER_LEN as u64,
+            u64::from(u32::MAX)
+        );
+        let params = WavParams::for_sample_type(SampleType::Int16Iq);
+        #[allow(clippy::cast_possible_truncation)]
+        let bytes = wav_header_finalized(u32::MAX, &params, 2_500_000);
+        assert_eq!(bytes[4..8], (u32::MAX - 8).to_le_bytes());
+        assert_eq!(bytes[40..44], (u32::MAX - 44).to_le_bytes());
     }
 
     #[test]

--- a/crates/airspy-tools/src/rx.rs
+++ b/crates/airspy-tools/src/rx.rs
@@ -7,6 +7,8 @@
 use libairspy_rs::Samples;
 use libairspy_rs::commands::SampleType;
 
+use crate::wav::WavParams;
+
 use crate::{ParseU64Error, parse_u64};
 
 /// `FREQ_ONE_MHZ` in `airspy_rx.c`.
@@ -43,121 +45,12 @@ pub const MIN_SAMPLERATE_BY_VALUE: u32 = 1_000_000;
 /// `FD_BUFFER_SIZE` in `airspy_rx.c` — the `setvbuf` output buffer.
 pub const FD_BUFFER_SIZE: usize = 16 * 1024;
 
-/// `sizeof(t_wav_file_hdr)` — 12-byte RIFF header + 24-byte format
-/// chunk + 8-byte data-chunk header, no padding.
-pub const WAV_HEADER_LEN: usize = 44;
-
-/// The most data bytes a classic RIFF/WAV file can carry: the 32-bit
-/// size fields cap the whole file at `u32::MAX` bytes, header
-/// included. C wraps its `uint32_t` `ftell` position past 4 GiB and
-/// writes corrupt size fields; deviation: `-w` captures stop at this
-/// budget so the finalized header is always representable.
-pub const WAV_MAX_DATA_BYTES: u64 = u32::MAX as u64 - WAV_HEADER_LEN as u64;
-
 /// The per-buffer window of the C rate average (`buffer_count == 50`
 /// in `rx_callback`).
 const RATE_WINDOW_BUFFERS: u32 = 50;
 /// The EWMA weight in `rx_callback`'s
 /// `average_rate += 0.2f * (rate - average_rate)`.
 const RATE_EWMA_WEIGHT: f32 = 0.2;
-
-/// The WAV format-chunk fields selected by `-t` in `airspy_rx.c` `main()`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct WavParams {
-    /// `wFormatTag`: 1 = PCM, 3 = IEEE float.
-    pub format_tag: u16,
-    /// `wChannels`: 2 for IQ, 1 for real/raw.
-    pub channels: u16,
-    /// `wBitsPerSample`.
-    pub bits_per_sample: u16,
-}
-
-impl WavParams {
-    /// The `-t` switch mapping in `airspy_rx.c` `main()`. The RAW case
-    /// sets only bits (12) and channels (1) in C; the format tag
-    /// keeps the PCM default (RAW is rejected for WAV output anyway).
-    pub fn for_sample_type(sample_type: SampleType) -> Self {
-        match sample_type {
-            SampleType::Float32Iq => Self {
-                format_tag: 3,
-                channels: 2,
-                bits_per_sample: 32,
-            },
-            SampleType::Float32Real => Self {
-                format_tag: 3,
-                channels: 1,
-                bits_per_sample: 32,
-            },
-            SampleType::Int16Iq => Self {
-                format_tag: 1,
-                channels: 2,
-                bits_per_sample: 16,
-            },
-            SampleType::Int16Real | SampleType::Uint16Real => Self {
-                format_tag: 1,
-                channels: 1,
-                bits_per_sample: 16,
-            },
-            SampleType::Raw => Self {
-                format_tag: 1,
-                channels: 1,
-                bits_per_sample: 12,
-            },
-        }
-    }
-
-    /// `wav_nb_byte_per_sample` (`wBitsPerSample / 8`).
-    pub fn bytes_per_sample(&self) -> u16 {
-        self.bits_per_sample / 8
-    }
-
-    /// `wBlockAlign` (`wChannels * wBitsPerSample / 8`).
-    pub fn block_align(&self) -> u16 {
-        self.channels * (self.bits_per_sample / 8)
-    }
-}
-
-/// The initial 44-byte header written before streaming — C's static
-/// `wave_file_hdr` initializer: chunk IDs and the fixed fmt-chunk size
-/// present, every "to update later" field zero.
-pub fn wav_header_placeholder() -> [u8; WAV_HEADER_LEN] {
-    let mut bytes = [0u8; WAV_HEADER_LEN];
-    bytes[0..4].copy_from_slice(b"RIFF");
-    bytes[8..12].copy_from_slice(b"WAVE");
-    bytes[12..16].copy_from_slice(b"fmt ");
-    bytes[16..20].copy_from_slice(&16u32.to_le_bytes());
-    bytes[36..40].copy_from_slice(b"data");
-    bytes
-}
-
-/// The end-of-capture header rewrite in `airspy_rx.c` `main()`:
-/// `size = file_pos - 8`, `data.chunkSize = file_pos - sizeof(hdr)`,
-/// format fields from the `-t` selection.
-///
-/// Deviation: C writes `dwAvgBytesPerSec = dwSamplesPerSec *
-/// wav_nb_byte_per_sample`, dropping the channel count — half the
-/// true byte rate for 2-channel IQ captures. The WAV spec value is
-/// `dwSamplesPerSec * wBlockAlign`, written here.
-pub fn wav_header_finalized(
-    file_pos: u32,
-    params: &WavParams,
-    samples_per_sec: u32,
-) -> [u8; WAV_HEADER_LEN] {
-    let mut bytes = wav_header_placeholder();
-    bytes[4..8].copy_from_slice(&(file_pos.wrapping_sub(8)).to_le_bytes());
-    bytes[20..22].copy_from_slice(&params.format_tag.to_le_bytes());
-    bytes[22..24].copy_from_slice(&params.channels.to_le_bytes());
-    bytes[24..28].copy_from_slice(&samples_per_sec.to_le_bytes());
-    let avg_bytes_per_sec = samples_per_sec.wrapping_mul(u32::from(params.block_align()));
-    bytes[28..32].copy_from_slice(&avg_bytes_per_sec.to_le_bytes());
-    bytes[32..34].copy_from_slice(&params.block_align().to_le_bytes());
-    bytes[34..36].copy_from_slice(&params.bits_per_sample.to_le_bytes());
-    // WAV_HEADER_LEN is 44; the cast cannot truncate.
-    #[allow(clippy::cast_possible_truncation)]
-    let data_len = file_pos.wrapping_sub(WAV_HEADER_LEN as u32);
-    bytes[40..44].copy_from_slice(&data_len.to_le_bytes());
-    bytes
-}
 
 /// `parse_u32` in `airspy_rx.c`: the same prefix detection as
 /// [`parse_u64`], then `strtoul` — which is 64-bit on the LP64
@@ -265,13 +158,6 @@ pub fn resolve_display_rate(sample_rate_val: u32, rates: &[u32]) -> Option<u32> 
     } else {
         Some(sample_rate_val)
     }
-}
-
-/// The `-w` automatic filename: `AirSpy_%sZ_%ukHz_IQ.wav` with the
-/// `%Y%m%d_%H%M%S` local time and `freq_hz / 1000` (`airspy_rx.c`
-/// `main()`).
-pub fn wav_filename(date_time: &str, freq_hz: u32) -> String {
-    format!("AirSpy_{date_time}Z_{}kHz_IQ.wav", freq_hz / 1000)
 }
 
 /// The streaming-rate bookkeeping from `rx_callback` in `airspy_rx.c`:
@@ -436,97 +322,6 @@ mod tests {
     }
 
     #[test]
-    fn wav_params_map_sample_types_like_c() {
-        // The -t switch cases in airspy_rx.c main(): format tag 3 is
-        // IEEE float, 1 is PCM.
-        let float_iq = WavParams::for_sample_type(SampleType::Float32Iq);
-        assert_eq!(
-            (
-                float_iq.format_tag,
-                float_iq.channels,
-                float_iq.bits_per_sample
-            ),
-            (3, 2, 32)
-        );
-        let float_real = WavParams::for_sample_type(SampleType::Float32Real);
-        assert_eq!(
-            (
-                float_real.format_tag,
-                float_real.channels,
-                float_real.bits_per_sample
-            ),
-            (3, 1, 32)
-        );
-        let int16_iq = WavParams::for_sample_type(SampleType::Int16Iq);
-        assert_eq!(
-            (
-                int16_iq.format_tag,
-                int16_iq.channels,
-                int16_iq.bits_per_sample
-            ),
-            (1, 2, 16)
-        );
-        let int16_real = WavParams::for_sample_type(SampleType::Int16Real);
-        assert_eq!((int16_real.channels, int16_real.bits_per_sample), (1, 16));
-        let uint16_real = WavParams::for_sample_type(SampleType::Uint16Real);
-        assert_eq!((uint16_real.channels, uint16_real.bits_per_sample), (1, 16));
-        // RAW: 12 bits, mono (the case 5 branch sets only these two).
-        let raw = WavParams::for_sample_type(SampleType::Raw);
-        assert_eq!((raw.channels, raw.bits_per_sample), (1, 12));
-    }
-
-    #[test]
-    fn wav_data_budget_keeps_sizes_representable() {
-        // A maximal capture finalizes to file_pos = u32::MAX with
-        // in-range RIFF and data sizes.
-        assert_eq!(
-            WAV_MAX_DATA_BYTES + WAV_HEADER_LEN as u64,
-            u64::from(u32::MAX)
-        );
-        let params = WavParams::for_sample_type(SampleType::Int16Iq);
-        #[allow(clippy::cast_possible_truncation)]
-        let bytes = wav_header_finalized(u32::MAX, &params, 2_500_000);
-        assert_eq!(bytes[4..8], (u32::MAX - 8).to_le_bytes());
-        assert_eq!(bytes[40..44], (u32::MAX - 44).to_le_bytes());
-    }
-
-    #[test]
-    fn wav_header_placeholder_matches_c_static_initializer() {
-        // wave_file_hdr's static initializer: chunk IDs and the fixed
-        // fmt-chunk size are set, every "to update later" field is 0.
-        let bytes = wav_header_placeholder();
-        assert_eq!(bytes.len(), WAV_HEADER_LEN);
-        assert_eq!(&bytes[0..4], b"RIFF");
-        assert_eq!(bytes[4..8], [0; 4]);
-        assert_eq!(&bytes[8..12], b"WAVE");
-        assert_eq!(&bytes[12..16], b"fmt ");
-        assert_eq!(bytes[16..20], 16u32.to_le_bytes());
-        assert_eq!(bytes[20..36], [0; 16]);
-        assert_eq!(&bytes[36..40], b"data");
-        assert_eq!(bytes[40..44], [0; 4]);
-    }
-
-    #[test]
-    fn wav_header_finalized_encodes_c_field_updates() {
-        // The end-of-main header rewrite in airspy_rx.c: size =
-        // file_pos - 8, data chunkSize = file_pos - sizeof(header),
-        // fmt fields from the -t selection.
-        let params = WavParams::for_sample_type(SampleType::Int16Iq);
-        let bytes = wav_header_finalized(10_044, &params, 2_500_000);
-        assert_eq!(bytes[4..8], 10_036u32.to_le_bytes());
-        assert_eq!(bytes[20..22], 1u16.to_le_bytes()); // wFormatTag
-        assert_eq!(bytes[22..24], 2u16.to_le_bytes()); // wChannels
-        assert_eq!(bytes[24..28], 2_500_000u32.to_le_bytes());
-        // dwAvgBytesPerSec — deviation: C writes dwSamplesPerSec *
-        // wav_nb_byte_per_sample (5_000_000 here), dropping the
-        // channel count; the WAV spec value is rate * block align.
-        assert_eq!(bytes[28..32], 10_000_000u32.to_le_bytes());
-        assert_eq!(bytes[32..34], 4u16.to_le_bytes()); // wBlockAlign
-        assert_eq!(bytes[34..36], 16u16.to_le_bytes()); // wBitsPerSample
-        assert_eq!(bytes[40..44], 10_000u32.to_le_bytes());
-    }
-
-    #[test]
     fn parse_u32_follows_c_strtoul_truncation() {
         // parse_u32 in airspy_rx.c stores strtoul's unsigned long
         // (64-bit on the LP64 platforms upstream targets) into a
@@ -597,20 +392,6 @@ mod tests {
         assert_eq!(resolve_display_rate(1_000_000, &rates), None);
         assert_eq!(resolve_display_rate(1_000_001, &rates), Some(1_000_001));
         assert_eq!(resolve_display_rate(6_000_000, &rates), Some(6_000_000));
-    }
-
-    #[test]
-    fn wav_filename_matches_c_snprintf_format() {
-        // snprintf(path_file, ..., "AirSpy_%sZ_%ukHz_IQ.wav",
-        // date_time, freq_hz / 1000).
-        assert_eq!(
-            wav_filename("20261225_101112", 100_000_000),
-            "AirSpy_20261225_101112Z_100000kHz_IQ.wav"
-        );
-        assert_eq!(
-            wav_filename("20130101_000000", 900_000_000),
-            "AirSpy_20130101_000000Z_900000kHz_IQ.wav"
-        );
     }
 
     #[test]

--- a/crates/airspy-tools/src/rx.rs
+++ b/crates/airspy-tools/src/rx.rs
@@ -356,18 +356,24 @@ pub fn frame_count(samples: &Samples<'_>, sample_type: SampleType, packing: bool
 /// the sample memory verbatim, which is little-endian on the wire and
 /// in the WAV/raw file formats.
 pub fn extend_sample_bytes(out: &mut Vec<u8>, samples: &Samples<'_>) {
+    // One up-front reservation instead of a capacity check per
+    // element — the caller reuses the buffer, so this is free after
+    // the first block.
     match samples {
         Samples::Float32(s) => {
+            out.reserve(std::mem::size_of_val(*s));
             for v in *s {
                 out.extend_from_slice(&v.to_le_bytes());
             }
         }
         Samples::Int16(s) => {
+            out.reserve(std::mem::size_of_val(*s));
             for v in *s {
                 out.extend_from_slice(&v.to_le_bytes());
             }
         }
         Samples::Uint16(s) => {
+            out.reserve(std::mem::size_of_val(*s));
             for v in *s {
                 out.extend_from_slice(&v.to_le_bytes());
             }

--- a/crates/airspy-tools/src/rx.rs
+++ b/crates/airspy-tools/src/rx.rs
@@ -1,0 +1,639 @@
+//! Shared logic for the `airspy_rx` binary, ported from
+//! `airspy-tools/src/airspy_rx.c`: WAV header handling, C-semantics
+//! argument parsing helpers, transfer byte accounting, and the
+//! streaming-rate tracker. Everything here is hardware-free and
+//! unit-tested; the binary wires it to a live device.
+
+use libairspy_rs::Samples;
+use libairspy_rs::commands::SampleType;
+
+use crate::{ParseU64Error, parse_u64};
+
+/// `FREQ_ONE_MHZ` in `airspy_rx.c`.
+pub const FREQ_ONE_MHZ: u32 = 1_000_000;
+/// `DEFAULT_FREQ_HZ` (900 MHz) in `airspy_rx.c`.
+pub const DEFAULT_FREQ_HZ: u32 = 900_000_000;
+/// `FREQ_HZ_MIN` (24 MHz) in `airspy_rx.c`.
+pub const FREQ_HZ_MIN: u32 = 24_000_000;
+/// `FREQ_HZ_MAX` in `airspy_rx.c` — "1900MHz (officially 1750MHz)".
+pub const FREQ_HZ_MAX: u32 = 1_900_000_000;
+/// `DEFAULT_VGA_IF_GAIN` in `airspy_rx.c`.
+pub const DEFAULT_VGA_IF_GAIN: u32 = 5;
+/// `DEFAULT_LNA_GAIN` in `airspy_rx.c`.
+pub const DEFAULT_LNA_GAIN: u32 = 1;
+/// `DEFAULT_MIXER_GAIN` in `airspy_rx.c`.
+pub const DEFAULT_MIXER_GAIN: u32 = 5;
+/// `VGA_GAIN_MAX` in `airspy_rx.c`.
+pub const VGA_GAIN_MAX: u32 = 15;
+/// `MIXER_GAIN_MAX` in `airspy_rx.c`.
+pub const MIXER_GAIN_MAX: u32 = 15;
+/// `LNA_GAIN_MAX` in `airspy_rx.c`.
+pub const LNA_GAIN_MAX: u32 = 14;
+/// `LINEARITY_GAIN_MAX` in `airspy_rx.c`.
+pub const LINEARITY_GAIN_MAX: u32 = 21;
+/// `SENSITIVITY_GAIN_MAX` in `airspy_rx.c`.
+pub const SENSITIVITY_GAIN_MAX: u32 = 21;
+/// `BIAST_MAX` in `airspy_rx.c`.
+pub const BIAST_MAX: u32 = 1;
+/// `SAMPLES_TO_XFER_MAX_U64` in `airspy_rx.c`.
+pub const SAMPLES_TO_XFER_MAX: u64 = 0x8000_0000_0000_0000;
+/// `MIN_SAMPLERATE_BY_VALUE` in `airspy_rx.c` — `-a` values at or below
+/// this are sample-rate-table indices, larger values are literal Hz.
+pub const MIN_SAMPLERATE_BY_VALUE: u32 = 1_000_000;
+/// `FD_BUFFER_SIZE` in `airspy_rx.c` — the `setvbuf` output buffer.
+pub const FD_BUFFER_SIZE: usize = 16 * 1024;
+
+/// `sizeof(t_wav_file_hdr)` — 12-byte RIFF header + 24-byte format
+/// chunk + 8-byte data-chunk header, no padding.
+pub const WAV_HEADER_LEN: usize = 44;
+
+/// The per-buffer window of the C rate average (`buffer_count == 50`
+/// in `rx_callback`).
+const RATE_WINDOW_BUFFERS: u32 = 50;
+/// The EWMA weight in `rx_callback`'s
+/// `average_rate += 0.2f * (rate - average_rate)`.
+const RATE_EWMA_WEIGHT: f32 = 0.2;
+
+/// The WAV format-chunk fields selected by `-t` in `airspy_rx.c` `main()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WavParams {
+    /// `wFormatTag`: 1 = PCM, 3 = IEEE float.
+    pub format_tag: u16,
+    /// `wChannels`: 2 for IQ, 1 for real/raw.
+    pub channels: u16,
+    /// `wBitsPerSample`.
+    pub bits_per_sample: u16,
+}
+
+impl WavParams {
+    /// The `-t` switch mapping in `airspy_rx.c` `main()`. The RAW case
+    /// sets only bits (12) and channels (1) in C; the format tag
+    /// keeps the PCM default (RAW is rejected for WAV output anyway).
+    pub fn for_sample_type(sample_type: SampleType) -> Self {
+        match sample_type {
+            SampleType::Float32Iq => Self {
+                format_tag: 3,
+                channels: 2,
+                bits_per_sample: 32,
+            },
+            SampleType::Float32Real => Self {
+                format_tag: 3,
+                channels: 1,
+                bits_per_sample: 32,
+            },
+            SampleType::Int16Iq => Self {
+                format_tag: 1,
+                channels: 2,
+                bits_per_sample: 16,
+            },
+            SampleType::Int16Real | SampleType::Uint16Real => Self {
+                format_tag: 1,
+                channels: 1,
+                bits_per_sample: 16,
+            },
+            SampleType::Raw => Self {
+                format_tag: 1,
+                channels: 1,
+                bits_per_sample: 12,
+            },
+        }
+    }
+
+    /// `wav_nb_byte_per_sample` (`wBitsPerSample / 8`).
+    pub fn bytes_per_sample(&self) -> u16 {
+        self.bits_per_sample / 8
+    }
+
+    /// `wBlockAlign` (`wChannels * wBitsPerSample / 8`).
+    pub fn block_align(&self) -> u16 {
+        self.channels * (self.bits_per_sample / 8)
+    }
+}
+
+/// The initial 44-byte header written before streaming — C's static
+/// `wave_file_hdr` initializer: chunk IDs and the fixed fmt-chunk size
+/// present, every "to update later" field zero.
+pub fn wav_header_placeholder() -> [u8; WAV_HEADER_LEN] {
+    let mut bytes = [0u8; WAV_HEADER_LEN];
+    bytes[0..4].copy_from_slice(b"RIFF");
+    bytes[8..12].copy_from_slice(b"WAVE");
+    bytes[12..16].copy_from_slice(b"fmt ");
+    bytes[16..20].copy_from_slice(&16u32.to_le_bytes());
+    bytes[36..40].copy_from_slice(b"data");
+    bytes
+}
+
+/// The end-of-capture header rewrite in `airspy_rx.c` `main()`:
+/// `size = file_pos - 8`, `data.chunkSize = file_pos - sizeof(hdr)`,
+/// format fields from the `-t` selection.
+///
+/// Deviation: C writes `dwAvgBytesPerSec = dwSamplesPerSec *
+/// wav_nb_byte_per_sample`, dropping the channel count — half the
+/// true byte rate for 2-channel IQ captures. The WAV spec value is
+/// `dwSamplesPerSec * wBlockAlign`, written here.
+pub fn wav_header_finalized(
+    file_pos: u32,
+    params: &WavParams,
+    samples_per_sec: u32,
+) -> [u8; WAV_HEADER_LEN] {
+    let mut bytes = wav_header_placeholder();
+    bytes[4..8].copy_from_slice(&(file_pos.wrapping_sub(8)).to_le_bytes());
+    bytes[20..22].copy_from_slice(&params.format_tag.to_le_bytes());
+    bytes[22..24].copy_from_slice(&params.channels.to_le_bytes());
+    bytes[24..28].copy_from_slice(&samples_per_sec.to_le_bytes());
+    let avg_bytes_per_sec = samples_per_sec.wrapping_mul(u32::from(params.block_align()));
+    bytes[28..32].copy_from_slice(&avg_bytes_per_sec.to_le_bytes());
+    bytes[32..34].copy_from_slice(&params.block_align().to_le_bytes());
+    bytes[34..36].copy_from_slice(&params.bits_per_sample.to_le_bytes());
+    // WAV_HEADER_LEN is 44; the cast cannot truncate.
+    #[allow(clippy::cast_possible_truncation)]
+    let data_len = file_pos.wrapping_sub(WAV_HEADER_LEN as u32);
+    bytes[40..44].copy_from_slice(&data_len.to_le_bytes());
+    bytes
+}
+
+/// `parse_u32` in `airspy_rx.c`: the same prefix detection as
+/// [`parse_u64`], then `strtoul` — which is 64-bit on the LP64
+/// platforms upstream targets, so out-of-range values saturate to
+/// `ULONG_MAX` and then truncate into the `uint32_t` result.
+#[allow(clippy::cast_possible_truncation)]
+pub fn parse_u32(s: &str) -> Result<u32, ParseU64Error> {
+    parse_u64(s).map(|v| v as u32)
+}
+
+/// `strtod(s, NULL)`'s longest-valid-prefix parse, restricted to the
+/// decimal forms the tool sees: optional whitespace and sign, digits
+/// with an optional fraction, optional exponent. C's hex-float and
+/// inf/nan spellings are not recognized (they parse as 0, the
+/// no-conversion result).
+fn strtod_prefix(s: &str) -> f64 {
+    let trimmed = s.trim_start_matches([' ', '\t', '\n', '\x0B', '\x0C', '\r']);
+    let bytes = trimmed.as_bytes();
+    let mut pos = 0;
+    if matches!(bytes.first(), Some(b'+' | b'-')) {
+        pos += 1;
+    }
+    let int_digits = bytes[pos..]
+        .iter()
+        .take_while(|b| b.is_ascii_digit())
+        .count();
+    pos += int_digits;
+    let mut frac_digits = 0;
+    if bytes.get(pos) == Some(&b'.') {
+        frac_digits = bytes[pos + 1..]
+            .iter()
+            .take_while(|b| b.is_ascii_digit())
+            .count();
+        pos += 1 + frac_digits;
+    }
+    if int_digits == 0 && frac_digits == 0 {
+        return 0.0;
+    }
+    if matches!(bytes.get(pos), Some(b'e' | b'E')) {
+        let mut exp_pos = pos + 1;
+        if matches!(bytes.get(exp_pos), Some(b'+' | b'-')) {
+            exp_pos += 1;
+        }
+        let exp_digits = bytes[exp_pos..]
+            .iter()
+            .take_while(|b| b.is_ascii_digit())
+            .count();
+        // The exponent is only part of the number when at least one
+        // digit follows, matching strtod's longest-match rule.
+        if exp_digits > 0 {
+            pos = exp_pos + exp_digits;
+        }
+    }
+    trimmed[..pos].parse().unwrap_or(0.0)
+}
+
+/// The `-f` branch in `airspy_rx.c` `main()`: `strtod(optarg, NULL) *
+/// FREQ_ONE_MHZ`, with results above `FREQ_HZ_MAX` becoming
+/// `UINT_MAX` so the later range check rejects them. (Rust's
+/// saturating float→int cast replaces C's out-of-range cast UB; both
+/// land outside the accepted range.)
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+pub fn parse_freq_mhz(s: &str) -> u32 {
+    let freq_hz = strtod_prefix(s) * f64::from(FREQ_ONE_MHZ);
+    if freq_hz <= f64::from(FREQ_HZ_MAX) {
+        freq_hz as u32
+    } else {
+        u32::MAX
+    }
+}
+
+/// `bytes_to_xfer = samples_to_xfer * wav_nb_bits_per_sample *
+/// wav_nb_channels / 8` in `airspy_rx.c` `main()`.
+///
+/// Deviation: C uses the RAW 12-bit figure whether or not packing is
+/// enabled, so unpacked RAW captures (16-bit words on the wire) stop
+/// at 75% of the requested samples; the unpacked case uses 16 bits
+/// here.
+pub fn bytes_to_xfer(
+    samples_to_xfer: u64,
+    params: &WavParams,
+    sample_type: SampleType,
+    packing: bool,
+) -> u64 {
+    let bits = if sample_type == SampleType::Raw && !packing {
+        16
+    } else {
+        u64::from(params.bits_per_sample)
+    };
+    // C's unsigned arithmetic wraps; the only values that can wrap
+    // are >= SAMPLES_TO_XFER_MAX, which the caller rejects anyway.
+    samples_to_xfer
+        .wrapping_mul(bits)
+        .wrapping_mul(u64::from(params.channels))
+        / 8
+}
+
+/// The sample-rate resolution in `airspy_rx.c` `main()`: values at or
+/// below [`MIN_SAMPLERATE_BY_VALUE`] index the supported-rate table
+/// (`None` when out of range — C errors out), larger values are
+/// literal Hz.
+pub fn resolve_display_rate(sample_rate_val: u32, rates: &[u32]) -> Option<u32> {
+    if sample_rate_val <= MIN_SAMPLERATE_BY_VALUE {
+        rates.get(sample_rate_val as usize).copied()
+    } else {
+        Some(sample_rate_val)
+    }
+}
+
+/// The `-w` automatic filename: `AirSpy_%sZ_%ukHz_IQ.wav` with the
+/// `%Y%m%d_%H%M%S` local time and `freq_hz / 1000` (`airspy_rx.c`
+/// `main()`).
+pub fn wav_filename(date_time: &str, freq_hz: u32) -> String {
+    format!("AirSpy_{date_time}Z_{}kHz_IQ.wav", freq_hz / 1000)
+}
+
+/// The streaming-rate bookkeeping from `rx_callback` in `airspy_rx.c`:
+/// the first packet latches the start times; afterwards every
+/// 50th buffer (`RATE_WINDOW_BUFFERS`) computes the window rate, applies
+/// the 0.2 EWMA into `average_rate`, and accumulates
+/// `global_average_rate` / `rate_samples` for the exit summary.
+#[derive(Debug)]
+pub struct RateTracker {
+    /// C's `average_rate`, seeded with the nominal sample rate.
+    pub average_rate: f32,
+    /// C's `global_average_rate` (sum of window averages).
+    pub global_average_rate: f32,
+    /// C's `rate_samples` (number of completed windows).
+    pub rate_samples: u32,
+    /// C's `t_start` — the first packet's arrival, for the total-time
+    /// summary.
+    pub t_start: Option<f64>,
+    time_start: f64,
+    buffer_count: u32,
+    sample_count: u32,
+}
+
+impl RateTracker {
+    /// `average_rate = (float)wav_sample_per_sec` before the C main
+    /// loop.
+    pub fn new(nominal_rate: f32) -> Self {
+        Self {
+            average_rate: nominal_rate,
+            global_average_rate: 0.0,
+            rate_samples: 0,
+            t_start: None,
+            time_start: 0.0,
+            buffer_count: 0,
+            sample_count: 0,
+        }
+    }
+
+    /// One delivered buffer of `samples` samples at time `now`
+    /// (seconds; any epoch — only differences are used).
+    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+    pub fn on_block(&mut self, samples: u32, now: f64) {
+        if self.t_start.is_none() {
+            self.t_start = Some(now);
+            self.time_start = now;
+            return;
+        }
+        self.buffer_count += 1;
+        self.sample_count += samples;
+        if self.buffer_count == RATE_WINDOW_BUFFERS {
+            // TimevalDiff returns float; the window rate is float math
+            // in C too.
+            let time_difference = (now - self.time_start) as f32;
+            let rate = self.sample_count as f32 / time_difference;
+            self.average_rate += RATE_EWMA_WEIGHT * (rate - self.average_rate);
+            self.global_average_rate += self.average_rate;
+            self.rate_samples += 1;
+            self.time_start = now;
+            self.sample_count = 0;
+            self.buffer_count = 0;
+        }
+    }
+}
+
+/// C's `transfer->sample_count` for a delivered block: frames (IQ
+/// pairs count once) for the converted types, and for RAW the sample
+/// count behind the wire bytes — `len * 2 / 3` packed 12-bit,
+/// `len / 2` unpacked 16-bit words.
+#[allow(clippy::cast_possible_truncation)]
+pub fn frame_count(samples: &Samples<'_>, sample_type: SampleType, packing: bool) -> u32 {
+    let frames = match samples {
+        Samples::Float32(s) if sample_type == SampleType::Float32Iq => s.len() / 2,
+        Samples::Int16(s) if sample_type == SampleType::Int16Iq => s.len() / 2,
+        Samples::Float32(s) => s.len(),
+        Samples::Int16(s) => s.len(),
+        Samples::Uint16(s) => s.len(),
+        Samples::Raw(s) => {
+            if packing {
+                s.len() * 2 / 3
+            } else {
+                s.len() / 2
+            }
+        }
+    };
+    frames as u32
+}
+
+/// Append a delivered block's bytes as `rx_callback`'s `fwrite` does —
+/// the sample memory verbatim, which is little-endian on the wire and
+/// in the WAV/raw file formats.
+pub fn extend_sample_bytes(out: &mut Vec<u8>, samples: &Samples<'_>) {
+    match samples {
+        Samples::Float32(s) => {
+            for v in *s {
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+        }
+        Samples::Int16(s) => {
+            for v in *s {
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+        }
+        Samples::Uint16(s) => {
+            for v in *s {
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+        }
+        Samples::Raw(s) => out.extend_from_slice(s),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libairspy_rs::Samples;
+    use libairspy_rs::commands::SampleType;
+
+    #[test]
+    fn constants_match_c_defines() {
+        // airspy_rx.c #defines.
+        assert_eq!(FREQ_ONE_MHZ, 1_000_000);
+        assert_eq!(DEFAULT_FREQ_HZ, 900_000_000);
+        assert_eq!(FREQ_HZ_MIN, 24_000_000);
+        assert_eq!(FREQ_HZ_MAX, 1_900_000_000);
+        assert_eq!(DEFAULT_VGA_IF_GAIN, 5);
+        assert_eq!(DEFAULT_LNA_GAIN, 1);
+        assert_eq!(DEFAULT_MIXER_GAIN, 5);
+        assert_eq!(VGA_GAIN_MAX, 15);
+        assert_eq!(MIXER_GAIN_MAX, 15);
+        assert_eq!(LNA_GAIN_MAX, 14);
+        assert_eq!(LINEARITY_GAIN_MAX, 21);
+        assert_eq!(SENSITIVITY_GAIN_MAX, 21);
+        assert_eq!(BIAST_MAX, 1);
+        assert_eq!(SAMPLES_TO_XFER_MAX, 0x8000_0000_0000_0000);
+        assert_eq!(MIN_SAMPLERATE_BY_VALUE, 1_000_000);
+        assert_eq!(FD_BUFFER_SIZE, 16 * 1024);
+    }
+
+    #[test]
+    fn wav_params_map_sample_types_like_c() {
+        // The -t switch cases in airspy_rx.c main(): format tag 3 is
+        // IEEE float, 1 is PCM.
+        let float_iq = WavParams::for_sample_type(SampleType::Float32Iq);
+        assert_eq!(
+            (
+                float_iq.format_tag,
+                float_iq.channels,
+                float_iq.bits_per_sample
+            ),
+            (3, 2, 32)
+        );
+        let float_real = WavParams::for_sample_type(SampleType::Float32Real);
+        assert_eq!(
+            (
+                float_real.format_tag,
+                float_real.channels,
+                float_real.bits_per_sample
+            ),
+            (3, 1, 32)
+        );
+        let int16_iq = WavParams::for_sample_type(SampleType::Int16Iq);
+        assert_eq!(
+            (
+                int16_iq.format_tag,
+                int16_iq.channels,
+                int16_iq.bits_per_sample
+            ),
+            (1, 2, 16)
+        );
+        let int16_real = WavParams::for_sample_type(SampleType::Int16Real);
+        assert_eq!((int16_real.channels, int16_real.bits_per_sample), (1, 16));
+        let uint16_real = WavParams::for_sample_type(SampleType::Uint16Real);
+        assert_eq!((uint16_real.channels, uint16_real.bits_per_sample), (1, 16));
+        // RAW: 12 bits, mono (the case 5 branch sets only these two).
+        let raw = WavParams::for_sample_type(SampleType::Raw);
+        assert_eq!((raw.channels, raw.bits_per_sample), (1, 12));
+    }
+
+    #[test]
+    fn wav_header_placeholder_matches_c_static_initializer() {
+        // wave_file_hdr's static initializer: chunk IDs and the fixed
+        // fmt-chunk size are set, every "to update later" field is 0.
+        let bytes = wav_header_placeholder();
+        assert_eq!(bytes.len(), WAV_HEADER_LEN);
+        assert_eq!(&bytes[0..4], b"RIFF");
+        assert_eq!(bytes[4..8], [0; 4]);
+        assert_eq!(&bytes[8..12], b"WAVE");
+        assert_eq!(&bytes[12..16], b"fmt ");
+        assert_eq!(bytes[16..20], 16u32.to_le_bytes());
+        assert_eq!(bytes[20..36], [0; 16]);
+        assert_eq!(&bytes[36..40], b"data");
+        assert_eq!(bytes[40..44], [0; 4]);
+    }
+
+    #[test]
+    fn wav_header_finalized_encodes_c_field_updates() {
+        // The end-of-main header rewrite in airspy_rx.c: size =
+        // file_pos - 8, data chunkSize = file_pos - sizeof(header),
+        // fmt fields from the -t selection.
+        let params = WavParams::for_sample_type(SampleType::Int16Iq);
+        let bytes = wav_header_finalized(10_044, &params, 2_500_000);
+        assert_eq!(bytes[4..8], 10_036u32.to_le_bytes());
+        assert_eq!(bytes[20..22], 1u16.to_le_bytes()); // wFormatTag
+        assert_eq!(bytes[22..24], 2u16.to_le_bytes()); // wChannels
+        assert_eq!(bytes[24..28], 2_500_000u32.to_le_bytes());
+        // dwAvgBytesPerSec — deviation: C writes dwSamplesPerSec *
+        // wav_nb_byte_per_sample (5_000_000 here), dropping the
+        // channel count; the WAV spec value is rate * block align.
+        assert_eq!(bytes[28..32], 10_000_000u32.to_le_bytes());
+        assert_eq!(bytes[32..34], 4u16.to_le_bytes()); // wBlockAlign
+        assert_eq!(bytes[34..36], 16u16.to_le_bytes()); // wBitsPerSample
+        assert_eq!(bytes[40..44], 10_000u32.to_le_bytes());
+    }
+
+    #[test]
+    fn parse_u32_follows_c_strtoul_truncation() {
+        // parse_u32 in airspy_rx.c stores strtoul's unsigned long
+        // (64-bit on the LP64 platforms upstream targets) into a
+        // uint32_t — values beyond 32 bits truncate, overflow
+        // saturates to ULONG_MAX first.
+        assert_eq!(parse_u32("42"), Ok(42));
+        assert_eq!(parse_u32("0x10"), Ok(16));
+        assert_eq!(parse_u32("0b101"), Ok(5));
+        assert_eq!(parse_u32("0x1FFFFFFFF"), Ok(0xFFFF_FFFF));
+        assert_eq!(parse_u32("-1"), Ok(0xFFFF_FFFF));
+        assert_eq!(parse_u32("99999999999999999999999"), Ok(0xFFFF_FFFF));
+        assert!(parse_u32("12abc").is_err());
+        assert!(parse_u32("").is_err());
+    }
+
+    #[test]
+    fn parse_freq_mhz_uses_strtod_prefix_semantics() {
+        // The -f branch: strtod(optarg, NULL) * 1e6, then values above
+        // FREQ_HZ_MAX become UINT_MAX (rejected by the later range
+        // check); strtod parses the longest valid prefix and yields 0
+        // when nothing parses.
+        assert_eq!(parse_freq_mhz("100"), 100_000_000);
+        assert_eq!(parse_freq_mhz("0.1"), 100_000);
+        assert_eq!(parse_freq_mhz("12.5e1"), 125_000_000);
+        assert_eq!(parse_freq_mhz(" 100"), 100_000_000);
+        assert_eq!(parse_freq_mhz("100abc"), 100_000_000);
+        assert_eq!(parse_freq_mhz("1900"), 1_900_000_000);
+        assert_eq!(parse_freq_mhz("2000"), u32::MAX);
+        assert_eq!(parse_freq_mhz("abc"), 0);
+        assert_eq!(parse_freq_mhz(""), 0);
+        // A negative parse cannot reach the valid range either way.
+        assert!(parse_freq_mhz("-100") < FREQ_HZ_MIN);
+    }
+
+    #[test]
+    fn bytes_to_xfer_matches_c_formula_with_raw_fix() {
+        // C: bytes_to_xfer = samples * bits * channels / 8. For RAW
+        // that always uses 12 bits — correct when packing is on,
+        // wrong (unpacked words are 16-bit) when off; deviation: the
+        // unpacked case uses 16 bits.
+        let iq16 = WavParams::for_sample_type(SampleType::Int16Iq);
+        assert_eq!(bytes_to_xfer(1000, &iq16, SampleType::Int16Iq, false), 4000);
+        let fiq = WavParams::for_sample_type(SampleType::Float32Iq);
+        assert_eq!(
+            bytes_to_xfer(1000, &fiq, SampleType::Float32Iq, false),
+            8000
+        );
+        let raw = WavParams::for_sample_type(SampleType::Raw);
+        assert_eq!(bytes_to_xfer(1000, &raw, SampleType::Raw, true), 1500);
+        assert_eq!(bytes_to_xfer(1000, &raw, SampleType::Raw, false), 2000);
+        // Values at/above SAMPLES_TO_XFER_MAX wrap like C's unsigned
+        // arithmetic; the caller rejects them right after computing.
+        assert_eq!(
+            bytes_to_xfer(SAMPLES_TO_XFER_MAX, &iq16, SampleType::Int16Iq, false),
+            0
+        );
+    }
+
+    #[test]
+    fn resolve_display_rate_treats_small_values_as_indices() {
+        // main() in airspy_rx.c: sample_rate_val <=
+        // MIN_SAMPLERATE_BY_VALUE selects supported_samplerates[val]
+        // (val >= count is an error); larger values are literal Hz.
+        let rates = [10_000_000, 2_500_000];
+        assert_eq!(resolve_display_rate(0, &rates), Some(10_000_000));
+        assert_eq!(resolve_display_rate(1, &rates), Some(2_500_000));
+        assert_eq!(resolve_display_rate(2, &rates), None);
+        assert_eq!(resolve_display_rate(1_000_000, &rates), None);
+        assert_eq!(resolve_display_rate(1_000_001, &rates), Some(1_000_001));
+        assert_eq!(resolve_display_rate(6_000_000, &rates), Some(6_000_000));
+    }
+
+    #[test]
+    fn wav_filename_matches_c_snprintf_format() {
+        // snprintf(path_file, ..., "AirSpy_%sZ_%ukHz_IQ.wav",
+        // date_time, freq_hz / 1000).
+        assert_eq!(
+            wav_filename("20261225_101112", 100_000_000),
+            "AirSpy_20261225_101112Z_100000kHz_IQ.wav"
+        );
+        assert_eq!(
+            wav_filename("20130101_000000", 900_000_000),
+            "AirSpy_20130101_000000Z_900000kHz_IQ.wav"
+        );
+    }
+
+    #[test]
+    fn rate_tracker_mirrors_c_averaging() {
+        // rx_callback in airspy_rx.c: the first packet only latches
+        // the start times; afterwards every 50th buffer computes
+        // rate = sample_count / elapsed, applies the 0.2 EWMA, and
+        // accumulates the global average.
+        let mut tracker = RateTracker::new(0.0);
+        tracker.on_block(1000, 0.0);
+        assert_eq!(tracker.rate_samples, 0);
+        for i in 1..=49 {
+            tracker.on_block(1000, f64::from(i) * 0.02);
+        }
+        assert_eq!(tracker.rate_samples, 0);
+        tracker.on_block(1000, 1.0);
+        // 50 blocks * 1000 samples over 1 s → rate 50_000; EWMA from
+        // 0.0 → 0.2 * 50_000 = 10_000.
+        assert_eq!(tracker.rate_samples, 1);
+        assert!((tracker.average_rate - 10_000.0).abs() < 1.0);
+        assert!((tracker.global_average_rate - 10_000.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn frame_count_matches_c_sample_count() {
+        // IQ types count pairs; real types count elements; RAW counts
+        // the samples behind the bytes (12-bit packed or 16-bit words).
+        let f = [0.0f32; 8];
+        assert_eq!(
+            frame_count(&Samples::Float32(&f), SampleType::Float32Iq, false),
+            4
+        );
+        assert_eq!(
+            frame_count(&Samples::Float32(&f), SampleType::Float32Real, false),
+            8
+        );
+        let i = [0i16; 8];
+        assert_eq!(
+            frame_count(&Samples::Int16(&i), SampleType::Int16Iq, false),
+            4
+        );
+        assert_eq!(
+            frame_count(&Samples::Int16(&i), SampleType::Int16Real, false),
+            8
+        );
+        let u = [0u16; 8];
+        assert_eq!(
+            frame_count(&Samples::Uint16(&u), SampleType::Uint16Real, false),
+            8
+        );
+        let raw = [0u8; 12];
+        assert_eq!(frame_count(&Samples::Raw(&raw), SampleType::Raw, true), 8);
+        assert_eq!(frame_count(&Samples::Raw(&raw), SampleType::Raw, false), 6);
+    }
+
+    #[test]
+    fn extend_sample_bytes_serializes_little_endian() {
+        // rx_callback writes the sample buffer's raw memory; the wire
+        // and WAV formats are little-endian.
+        let mut out = Vec::new();
+        extend_sample_bytes(&mut out, &Samples::Int16(&[1, -2]));
+        assert_eq!(out, [1, 0, 0xFE, 0xFF]);
+        out.clear();
+        extend_sample_bytes(&mut out, &Samples::Uint16(&[0x1234]));
+        assert_eq!(out, [0x34, 0x12]);
+        out.clear();
+        extend_sample_bytes(&mut out, &Samples::Float32(&[1.0]));
+        assert_eq!(out, 1.0f32.to_le_bytes());
+        out.clear();
+        extend_sample_bytes(&mut out, &Samples::Raw(&[9, 8, 7]));
+        assert_eq!(out, [9, 8, 7]);
+    }
+}

--- a/crates/airspy-tools/src/rx.rs
+++ b/crates/airspy-tools/src/rx.rs
@@ -336,6 +336,25 @@ impl RateTracker {
     }
 }
 
+/// The `-n` limiting from `rx_callback` in `airspy_rx.c`: clamp the
+/// block to the remaining budget and deduct what will be written.
+/// Returns the byte count to write; `None` means unlimited.
+#[allow(clippy::cast_possible_truncation)]
+pub fn apply_byte_budget(remaining: &mut Option<u64>, block_len: usize) -> usize {
+    let Some(remaining) = remaining.as_mut() else {
+        return block_len;
+    };
+    // C: if (bytes_to_write >= bytes_to_xfer) bytes_to_write =
+    // bytes_to_xfer; bytes_to_xfer -= bytes_to_write;
+    let bytes_to_write = if block_len as u64 >= *remaining {
+        *remaining as usize
+    } else {
+        block_len
+    };
+    *remaining -= bytes_to_write as u64;
+    bytes_to_write
+}
+
 /// C's `transfer->sample_count` for a delivered block: frames (IQ
 /// pairs count once) for the converted types, and for RAW the sample
 /// count behind the wire bytes — `len * 2 / 3` packed 12-bit,
@@ -613,6 +632,25 @@ mod tests {
         assert_eq!(tracker.rate_samples, 1);
         assert!((tracker.average_rate - 10_000.0).abs() < 1.0);
         assert!((tracker.global_average_rate - 10_000.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn apply_byte_budget_clamps_and_deducts_like_c() {
+        // No -n: everything is written, nothing tracked.
+        let mut unlimited = None;
+        assert_eq!(apply_byte_budget(&mut unlimited, 4096), 4096);
+        assert_eq!(unlimited, None);
+        // Budget larger than the block: full write, deducted.
+        let mut remaining = Some(10_000u64);
+        assert_eq!(apply_byte_budget(&mut remaining, 4096), 4096);
+        assert_eq!(remaining, Some(5904));
+        // Budget smaller than the block: clamp, then exhausted.
+        let mut remaining = Some(100u64);
+        assert_eq!(apply_byte_budget(&mut remaining, 4096), 100);
+        assert_eq!(remaining, Some(0));
+        // Exhausted budget writes nothing.
+        assert_eq!(apply_byte_budget(&mut remaining, 4096), 0);
+        assert_eq!(remaining, Some(0));
     }
 
     #[test]

--- a/crates/airspy-tools/src/rx.rs
+++ b/crates/airspy-tools/src/rx.rs
@@ -61,17 +61,90 @@ pub fn parse_u32(s: &str) -> Result<u32, ParseU64Error> {
     parse_u64(s).map(|v| v as u32)
 }
 
-/// `strtod(s, NULL)`'s longest-valid-prefix parse, restricted to the
-/// decimal forms the tool sees: optional whitespace and sign, digits
-/// with an optional fraction, optional exponent. C's hex-float and
-/// inf/nan spellings are not recognized (they parse as 0, the
-/// no-conversion result).
+/// C99's `0x` significand with an optional `p`/`P` binary exponent
+/// (`strtod` accepts e.g. `0x1p10` = 1024.0 and `0x1A` = 26.0):
+/// accumulate the hex digits around the optional point, then scale by
+/// `2^(exponent - 4 * fraction digits)`. `None` when no hex digit
+/// follows the prefix — strtod's longest match is then the bare `0`.
+fn hex_float_prefix(bytes: &[u8]) -> Option<f64> {
+    let mut mantissa = 0.0f64;
+    let mut digits = 0usize;
+    let mut frac_digits = 0i32;
+    let mut pos = 0usize;
+    while let Some(d) = bytes.get(pos).and_then(|b| char::from(*b).to_digit(16)) {
+        mantissa = mantissa * 16.0 + f64::from(d);
+        digits += 1;
+        pos += 1;
+    }
+    if bytes.get(pos) == Some(&b'.') {
+        let mut after = pos + 1;
+        while let Some(d) = bytes.get(after).and_then(|b| char::from(*b).to_digit(16)) {
+            mantissa = mantissa * 16.0 + f64::from(d);
+            digits += 1;
+            frac_digits += 1;
+            after += 1;
+        }
+        // The point joins the token only when digits exist at all
+        // (strtod: "0x.p" has no significand and does not convert).
+        if digits > 0 {
+            pos = after;
+        }
+    }
+    if digits == 0 {
+        return None;
+    }
+    let mut exponent = 0i32;
+    if matches!(bytes.get(pos), Some(b'p' | b'P')) {
+        let mut exp_pos = pos + 1;
+        let negative_exp = match bytes.get(exp_pos) {
+            Some(b'-') => {
+                exp_pos += 1;
+                true
+            }
+            Some(b'+') => {
+                exp_pos += 1;
+                false
+            }
+            _ => false,
+        };
+        let mut exp_digits = 0usize;
+        let mut value = 0i32;
+        while let Some(d) = bytes.get(exp_pos).and_then(|b| char::from(*b).to_digit(10)) {
+            // Saturating: powi over/underflows to inf/0 exactly as
+            // strtod does for out-of-range exponents.
+            #[allow(clippy::cast_possible_wrap)]
+            let d = d as i32;
+            value = value.saturating_mul(10).saturating_add(d);
+            exp_digits += 1;
+            exp_pos += 1;
+        }
+        // `p` with no digit is not part of the token (longest match).
+        if exp_digits > 0 {
+            exponent = if negative_exp { -value } else { value };
+        }
+    }
+    Some(mantissa * 2.0f64.powi(exponent.saturating_sub(frac_digits.saturating_mul(4))))
+}
+
+/// `strtod(s, NULL)`'s longest-valid-prefix parse over the forms the
+/// tool sees: optional whitespace and sign, then either a decimal
+/// significand with an optional `e` exponent or a C99 `0x` hex float
+/// with an optional `p` binary exponent. The `inf`/`nan` spellings
+/// are not recognized (they parse as 0; both 0 and the C values fail
+/// the frequency range check identically).
 fn strtod_prefix(s: &str) -> f64 {
     let trimmed = s.trim_start_matches([' ', '\t', '\n', '\x0B', '\x0C', '\r']);
     let bytes = trimmed.as_bytes();
     let mut pos = 0;
+    let negative = bytes.first() == Some(&b'-');
     if matches!(bytes.first(), Some(b'+' | b'-')) {
         pos += 1;
+    }
+    if bytes.get(pos) == Some(&b'0')
+        && matches!(bytes.get(pos + 1), Some(b'x' | b'X'))
+        && let Some(value) = hex_float_prefix(&bytes[pos + 2..])
+    {
+        return if negative { -value } else { value };
     }
     let int_digits = bytes[pos..]
         .iter()
@@ -354,6 +427,30 @@ mod tests {
         assert_eq!(parse_freq_mhz(""), 0);
         // A negative parse cannot reach the valid range either way.
         assert!(parse_freq_mhz("-100") < FREQ_HZ_MIN);
+    }
+
+    #[test]
+    fn parse_freq_mhz_accepts_c99_hex_floats() {
+        // strtod accepts the C99 hexadecimal form: 0x1p10 = 1024.0
+        // (so -f 0x1p10 is a valid 1024 MHz in the C tool), 0x1A = 26.0
+        // (binary exponent optional), 0x.8p1 = 1.0.
+        assert_eq!(parse_freq_mhz("0x1p10"), 1_024_000_000);
+        assert_eq!(parse_freq_mhz("0x1A"), 26_000_000);
+        assert_eq!(parse_freq_mhz("0x.8p1"), 1_000_000);
+        // Longest match: a bare `p` or trailing garbage is not
+        // consumed.
+        assert_eq!(parse_freq_mhz("0x1Ap"), 26_000_000);
+        assert_eq!(parse_freq_mhz("0x1p1zz"), 2_000_000);
+        assert_eq!(parse_freq_mhz("0x1p+4"), 16_000_000);
+        // No hex digit after 0x: strtod's longest match is the bare
+        // leading zero.
+        assert_eq!(parse_freq_mhz("0xp3"), 0);
+        assert_eq!(parse_freq_mhz("0x.p3"), 0);
+        // Sign applies; negatives cannot reach the valid range.
+        assert!(parse_freq_mhz("-0x1p10") < FREQ_HZ_MIN);
+        // Out-of-range binary exponents saturate like strtod's
+        // overflow (rejected by the caller's range check either way).
+        assert_eq!(parse_freq_mhz("0x1p99999"), u32::MAX);
     }
 
     #[test]

--- a/crates/airspy-tools/src/rx_cli.rs
+++ b/crates/airspy-tools/src/rx_cli.rs
@@ -10,9 +10,10 @@ use crate::parse_u64;
 use crate::rx::{
     BIAST_MAX, DEFAULT_FREQ_HZ, DEFAULT_LNA_GAIN, DEFAULT_MIXER_GAIN, DEFAULT_VGA_IF_GAIN,
     FREQ_HZ_MAX, FREQ_HZ_MIN, FREQ_ONE_MHZ, LINEARITY_GAIN_MAX, LNA_GAIN_MAX, MIXER_GAIN_MAX,
-    SAMPLES_TO_XFER_MAX, SENSITIVITY_GAIN_MAX, VGA_GAIN_MAX, WavParams, bytes_to_xfer,
-    parse_freq_mhz, parse_u32, wav_filename,
+    SAMPLES_TO_XFER_MAX, SENSITIVITY_GAIN_MAX, VGA_GAIN_MAX, bytes_to_xfer, parse_freq_mhz,
+    parse_u32,
 };
+use crate::wav::{WavParams, wav_filename};
 
 /// `AIRSPY_RX_VERSION` in `airspy_rx.c`.
 pub const AIRSPY_RX_VERSION: &str = "1.0.5 23 April 2016";

--- a/crates/airspy-tools/src/rx_cli.rs
+++ b/crates/airspy-tools/src/rx_cli.rs
@@ -174,13 +174,16 @@ pub struct Config {
 /// The `-t` value → sample type mapping from the C switch (`None` is
 /// the out-of-range marker checked later).
 fn sample_type_from_u32(value: u32) -> Option<SampleType> {
+    // The switch (sample_type_u32) cases 0..=5 in `airspy_rx.c`
+    // `main()`'s -t handler; the guards tie each case to the enum
+    // discriminant instead of repeating the literal.
     match value {
-        0 => Some(SampleType::Float32Iq),
-        1 => Some(SampleType::Float32Real),
-        2 => Some(SampleType::Int16Iq),
-        3 => Some(SampleType::Int16Real),
-        4 => Some(SampleType::Uint16Real),
-        5 => Some(SampleType::Raw),
+        v if v == SampleType::Float32Iq as u32 => Some(SampleType::Float32Iq),
+        v if v == SampleType::Float32Real as u32 => Some(SampleType::Float32Real),
+        v if v == SampleType::Int16Iq as u32 => Some(SampleType::Int16Iq),
+        v if v == SampleType::Int16Real as u32 => Some(SampleType::Int16Real),
+        v if v == SampleType::Uint16Real as u32 => Some(SampleType::Uint16Real),
+        v if v == SampleType::Raw as u32 => Some(SampleType::Raw),
         _ => None,
     }
 }

--- a/crates/airspy-tools/src/rx_cli.rs
+++ b/crates/airspy-tools/src/rx_cli.rs
@@ -1,0 +1,470 @@
+//! The CLI layer of the `airspy_rx` binary, ported from
+//! `airspy_rx.c`'s getopt loop, `usage()`, and the post-getopt
+//! validation section of `main()` — split from the binary so the
+//! whole argument surface is unit-testable.
+
+use clap::Parser;
+use libairspy_rs::commands::SampleType;
+
+use crate::parse_u64;
+use crate::rx::{
+    BIAST_MAX, DEFAULT_FREQ_HZ, DEFAULT_LNA_GAIN, DEFAULT_MIXER_GAIN, DEFAULT_VGA_IF_GAIN,
+    FREQ_HZ_MAX, FREQ_HZ_MIN, FREQ_ONE_MHZ, LINEARITY_GAIN_MAX, LNA_GAIN_MAX, MIXER_GAIN_MAX,
+    SAMPLES_TO_XFER_MAX, SENSITIVITY_GAIN_MAX, VGA_GAIN_MAX, WavParams, bytes_to_xfer,
+    parse_freq_mhz, parse_u32, wav_filename,
+};
+
+/// `AIRSPY_RX_VERSION` in `airspy_rx.c`.
+pub const AIRSPY_RX_VERSION: &str = "1.0.5 23 April 2016";
+
+/// The `airspy_rx` command line — one field per C getopt flag (the
+/// doc comments double as `--help` text).
+#[derive(Parser)]
+#[command(
+    name = "airspy_rx",
+    about = "Receive Airspy samples into a file",
+    disable_help_flag = true
+)]
+pub struct Args {
+    /// Receive data into file
+    #[arg(short = 'r', value_name = "filename")]
+    pub receive_file: Option<String>,
+
+    /// Receive data into file with WAV header and automatic name
+    #[arg(short = 'w')]
+    pub receive_wav: bool,
+
+    /// Open device with specified 64bits serial number
+    #[arg(short = 's', value_name = "serial_number_64bits", value_parser = parse_u64)]
+    pub serial_number: Option<u64>,
+
+    /// Set packing for samples: 1=enabled(12bits packed), 0=disabled
+    #[arg(short = 'p', value_name = "packing", value_parser = parse_u32)]
+    pub packing: Option<u32>,
+
+    /// Set frequency in MHz
+    #[arg(short = 'f', value_name = "frequency_MHz")]
+    pub freq_mhz: Option<String>,
+
+    /// Set sample rate (index or Hz)
+    #[arg(short = 'a', value_name = "sample_rate", value_parser = parse_u32)]
+    pub sample_rate: Option<u32>,
+
+    /// Set sample type: 0=`FLOAT32_IQ`, 1=`FLOAT32_REAL`, 2=`INT16_IQ`,
+    /// 3=`INT16_REAL`, 4=`U16_REAL`, 5=RAW
+    #[arg(short = 't', value_name = "sample_type", value_parser = parse_u32)]
+    pub sample_type: Option<u32>,
+
+    /// Set Bias Tee: 1=enabled, 0=disabled
+    #[arg(short = 'b', value_name = "biast", value_parser = parse_u32)]
+    pub biast: Option<u32>,
+
+    /// Set VGA/IF gain, 0-15
+    #[arg(short = 'v', value_name = "vga_gain", value_parser = parse_u32)]
+    pub vga_gain: Option<u32>,
+
+    /// Set Mixer gain, 0-15
+    #[arg(short = 'm', value_name = "mixer_gain", value_parser = parse_u32)]
+    pub mixer_gain: Option<u32>,
+
+    /// Set LNA gain, 0-14
+    #[arg(short = 'l', value_name = "lna_gain", value_parser = parse_u32)]
+    pub lna_gain: Option<u32>,
+
+    /// Set linearity simplified gain, 0-21
+    #[arg(short = 'g', value_name = "linearity_gain", value_parser = parse_u32)]
+    pub linearity_gain: Option<u32>,
+
+    /// Set sensitivity simplified gain, 0-21 (C's -h; use --help for
+    /// this text)
+    #[arg(short = 'h', value_name = "sensitivity_gain", value_parser = parse_u32)]
+    pub sensitivity_gain: Option<u32>,
+
+    /// Number of samples to transfer (default is unlimited)
+    #[arg(short = 'n', value_name = "num_samples", value_parser = parse_u64)]
+    pub num_samples: Option<u64>,
+
+    /// Verbose mode
+    #[arg(short = 'd')]
+    pub verbose: bool,
+
+    /// Print help
+    #[arg(long, action = clap::ArgAction::Help)]
+    pub help: Option<bool>,
+}
+
+/// The `usage()` text from `airspy_rx.c`, printed after argument
+/// errors.
+pub fn usage() {
+    eprintln!("airspy_rx v{AIRSPY_RX_VERSION}");
+    eprintln!("Usage:");
+    eprintln!("-r <filename>: Receive data into file");
+    eprintln!("-w Receive data into file with WAV header and automatic name");
+    eprintln!(" This is for SDR# compatibility and may not work with other software");
+    eprintln!("[-s serial_number_64bits]: Open device with specified 64bits serial number");
+    eprintln!("[-p packing]: Set packing for samples, ");
+    eprintln!(" 1=enabled(12bits packed), 0=disabled(default 16bits not packed)");
+    eprintln!(
+        "[-f frequency_MHz]: Set frequency in MHz between [{}, {}] (default {}MHz)",
+        FREQ_HZ_MIN / FREQ_ONE_MHZ,
+        FREQ_HZ_MAX / FREQ_ONE_MHZ,
+        DEFAULT_FREQ_HZ / FREQ_ONE_MHZ
+    );
+    eprintln!("[-a sample_rate]: Set sample rate");
+    eprintln!("[-t sample_type]: Set sample type, ");
+    eprintln!(
+        " 0=FLOAT32_IQ, 1=FLOAT32_REAL, 2=INT16_IQ(default), 3=INT16_REAL, 4=U16_REAL, 5=RAW"
+    );
+    eprintln!("[-b biast]: Set Bias Tee, 1=enabled, 0=disabled(default)");
+    eprintln!("[-v vga_gain]: Set VGA/IF gain, 0-{VGA_GAIN_MAX} (default {DEFAULT_VGA_IF_GAIN})");
+    eprintln!("[-m mixer_gain]: Set Mixer gain, 0-{MIXER_GAIN_MAX} (default {DEFAULT_MIXER_GAIN})");
+    eprintln!("[-l lna_gain]: Set LNA gain, 0-{LNA_GAIN_MAX} (default {DEFAULT_LNA_GAIN})");
+    eprintln!("[-g linearity_gain]: Set linearity simplified gain, 0-{LINEARITY_GAIN_MAX}");
+    eprintln!("[-h sensivity_gain]: Set sensitivity simplified gain, 0-{SENSITIVITY_GAIN_MAX}");
+    eprintln!("[-n num_samples]: Number of samples to transfer (default is unlimited)");
+    eprintln!("[-d]: Verbose mode");
+}
+
+/// The validated capture parameters, C's checked globals after the
+/// argument section of `main()`.
+// The bools mirror the C tool's independent flag globals.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug)]
+pub struct Config {
+    /// Output path (`-` is stdout; generated for `-w`).
+    pub path: String,
+    /// `-w`: WAV output with the automatic filename.
+    pub receive_wav: bool,
+    /// `-s`: open by 64-bit serial number.
+    pub serial_number: Option<u64>,
+    /// The `-p` value (12-bit packed transfers).
+    pub packing: bool,
+    /// Whether `-p` was given (C's `call_set_packing`).
+    pub call_set_packing: bool,
+    /// The tune frequency in Hz (validated or default).
+    pub freq_hz: u32,
+    /// The raw `-a` value (index or literal Hz; 0 default).
+    pub sample_rate_val: u32,
+    /// The validated `-t` selection.
+    pub sample_type: SampleType,
+    /// WAV format fields derived from the sample type.
+    pub wav_params: WavParams,
+    /// The `-b` value (bias tee).
+    pub biast: bool,
+    /// `-v` (validated, defaulted).
+    pub vga_gain: u32,
+    /// `-m` (validated, defaulted).
+    pub mixer_gain: u32,
+    /// `-l` (validated, defaulted).
+    pub lna_gain: u32,
+    /// `-g` if given.
+    pub linearity_gain: Option<u32>,
+    /// `-h` if given.
+    pub sensitivity_gain: Option<u32>,
+    /// Whether `-n` was given.
+    pub limit_num_samples: bool,
+    /// The `-n` sample count.
+    pub samples_to_xfer: u64,
+    /// The `-n` limit converted to output bytes.
+    pub bytes_to_xfer: u64,
+    /// `-d`.
+    pub verbose: bool,
+}
+
+/// The `-t` value → sample type mapping from the C switch (`None` is
+/// the out-of-range marker checked later).
+fn sample_type_from_u32(value: u32) -> Option<SampleType> {
+    match value {
+        0 => Some(SampleType::Float32Iq),
+        1 => Some(SampleType::Float32Real),
+        2 => Some(SampleType::Int16Iq),
+        3 => Some(SampleType::Int16Real),
+        4 => Some(SampleType::Uint16Real),
+        5 => Some(SampleType::Raw),
+        _ => None,
+    }
+}
+
+/// The `-f` handling from `airspy_rx.c` `main()`: parse with strtod
+/// semantics, enforce `[FREQ_HZ_MIN, FREQ_HZ_MAX[`, default 900 MHz.
+fn resolve_freq(args: &Args) -> Result<u32, String> {
+    let Some(s) = &args.freq_mhz else {
+        return Ok(DEFAULT_FREQ_HZ);
+    };
+    let hz = parse_freq_mhz(s);
+    if (FREQ_HZ_MIN..FREQ_HZ_MAX).contains(&hz) {
+        Ok(hz)
+    } else {
+        Err(format!(
+            "argument error: frequency_MHz={:.6} MHz and shall be between [{}, {}[ MHz",
+            f64::from(hz) / f64::from(FREQ_ONE_MHZ),
+            FREQ_HZ_MIN / FREQ_ONE_MHZ,
+            FREQ_HZ_MAX / FREQ_ONE_MHZ
+        ))
+    }
+}
+
+/// The output-path selection from `airspy_rx.c` `main()`: `-w` rejects
+/// RAW and generates the dated filename; otherwise `-r` is required.
+fn resolve_capture_path(
+    args: &Args,
+    sample_type: Option<SampleType>,
+    freq_hz: u32,
+    date_time: &str,
+) -> Result<String, String> {
+    if args.receive_wav {
+        if sample_type == Some(SampleType::Raw) {
+            return Err("The RAW sampling mode is not compatible with Wave files".into());
+        }
+        return Ok(wav_filename(date_time, freq_hz));
+    }
+    match &args.receive_file {
+        Some(p) => Ok(p.clone()),
+        None => Err("error: you shall specify at least -r <with filename> or -w option".into()),
+    }
+}
+
+/// The bias-T and gain range checks from `airspy_rx.c` `main()`, in
+/// C's order and with C's messages; returns the defaulted values.
+fn validate_ranges(args: &Args) -> Result<(u32, u32, u32, u32), String> {
+    let biast_val = args.biast.unwrap_or(0);
+    if biast_val > BIAST_MAX {
+        return Err("argument error: biast_val out of range".into());
+    }
+    let vga_gain = args.vga_gain.unwrap_or(DEFAULT_VGA_IF_GAIN);
+    if vga_gain > VGA_GAIN_MAX {
+        return Err("argument error: vga_gain out of range".into());
+    }
+    let mixer_gain = args.mixer_gain.unwrap_or(DEFAULT_MIXER_GAIN);
+    if mixer_gain > MIXER_GAIN_MAX {
+        return Err("argument error: mixer_gain out of range".into());
+    }
+    let lna_gain = args.lna_gain.unwrap_or(DEFAULT_LNA_GAIN);
+    if lna_gain > LNA_GAIN_MAX {
+        return Err("argument error: lna_gain out of range".into());
+    }
+    if args.linearity_gain.unwrap_or(0) > LINEARITY_GAIN_MAX {
+        return Err("argument error: linearity_gain out of range".into());
+    }
+    if args.sensitivity_gain.unwrap_or(0) > SENSITIVITY_GAIN_MAX {
+        return Err("argument error: sensitivity_gain out of range".into());
+    }
+    if args.linearity_gain.is_some() && args.sensitivity_gain.is_some() {
+        return Err(
+            "argument error: linearity_gain and sensitivity_gain are both set (choose only one option)"
+                .into(),
+        );
+    }
+    Ok((biast_val, vga_gain, mixer_gain, lna_gain))
+}
+
+/// Every post-getopt validation from `airspy_rx.c` `main()`, in C's order
+/// and with C's stderr messages. `date_time` is the pre-formatted
+/// `%Y%m%d_%H%M%S` local time for the `-w` automatic filename.
+///
+/// Deviation: C's `-b` case sets the *`serial_number`* flag instead of
+/// a bias-T flag (a copy-paste bug that makes a bare `-b 1` open
+/// serial number 0); here `-b` only controls the bias tee.
+pub fn build_config(args: &Args, date_time: &str) -> Result<Config, String> {
+    let sample_type = match args.sample_type {
+        None => Some(SampleType::Int16Iq),
+        Some(v) => sample_type_from_u32(v),
+    };
+    // The WAV parameters fall back to the int16 defaults while the
+    // sample type is invalid, exactly as C's globals do; the
+    // sample_type range check below fires before they are used.
+    let wav_params = WavParams::for_sample_type(sample_type.unwrap_or(SampleType::Int16Iq));
+
+    let samples_to_xfer = args.num_samples.unwrap_or(0);
+    let effective_type = sample_type.unwrap_or(SampleType::Int16Iq);
+    let packing = args.packing == Some(1);
+    let bytes = bytes_to_xfer(samples_to_xfer, &wav_params, effective_type, packing);
+
+    if samples_to_xfer >= SAMPLES_TO_XFER_MAX {
+        return Err(format!(
+            "argument error: num_samples must be less than {SAMPLES_TO_XFER_MAX}/{}Mio",
+            SAMPLES_TO_XFER_MAX / u64::from(FREQ_ONE_MHZ)
+        ));
+    }
+
+    let freq_hz = resolve_freq(args)?;
+    let path = resolve_capture_path(args, sample_type, freq_hz, date_time)?;
+    if let Some(p) = args.packing
+        && p > 1
+    {
+        return Err("argument error: packing out of range".into());
+    }
+    let Some(sample_type) = sample_type else {
+        return Err("argument error: sample_type out of range".into());
+    };
+    let (biast_val, vga_gain, mixer_gain, lna_gain) = validate_ranges(args)?;
+
+    Ok(Config {
+        path,
+        receive_wav: args.receive_wav,
+        serial_number: args.serial_number,
+        packing,
+        call_set_packing: args.packing.is_some(),
+        freq_hz,
+        sample_rate_val: args.sample_rate.unwrap_or(0),
+        sample_type,
+        wav_params,
+        biast: biast_val == 1,
+        vga_gain,
+        mixer_gain,
+        lna_gain,
+        linearity_gain: args.linearity_gain,
+        sensitivity_gain: args.sensitivity_gain,
+        limit_num_samples: args.num_samples.is_some(),
+        samples_to_xfer,
+        bytes_to_xfer: bytes,
+        verbose: args.verbose,
+    })
+}
+
+/// The `if (verbose)` argument dump in `airspy_rx.c` `main()`.
+pub fn print_verbose(config: &Config) {
+    eprintln!("airspy_rx v{AIRSPY_RX_VERSION}");
+    if let Some(serial) = config.serial_number {
+        eprintln!(
+            "serial_number_64bits -s 0x{:08X}{:08X}",
+            (serial >> 32) as u32,
+            (serial & 0xFFFF_FFFF) as u32
+        );
+    }
+    eprintln!("packing -p {}", u32::from(config.packing));
+    eprintln!(
+        "frequency_MHz -f {:.6}MHz ({}Hz)",
+        f64::from(config.freq_hz) / f64::from(FREQ_ONE_MHZ),
+        config.freq_hz
+    );
+    eprintln!("sample_type -t {}", config.sample_type as u8);
+    eprintln!("biast -b {}", u32::from(config.biast));
+    if config.linearity_gain.is_none() && config.sensitivity_gain.is_none() {
+        eprintln!("vga_gain -v {}", config.vga_gain);
+        eprintln!("mixer_gain -m {}", config.mixer_gain);
+        eprintln!("lna_gain -l {}", config.lna_gain);
+    } else {
+        if let Some(g) = config.linearity_gain {
+            eprintln!("linearity_gain -g {g}");
+        }
+        if let Some(g) = config.sensitivity_gain {
+            eprintln!("sensitivity_gain -h {g}");
+        }
+    }
+    if config.limit_num_samples {
+        eprintln!(
+            "num_samples -n {} ({}M)",
+            config.samples_to_xfer,
+            config.samples_to_xfer / u64::from(FREQ_ONE_MHZ)
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(argv: &[&str]) -> Args {
+        Args::try_parse_from(std::iter::once("airspy_rx").chain(argv.iter().copied()))
+            .expect("args parse")
+    }
+
+    #[test]
+    fn args_mirror_c_flags() {
+        let args = parse(&[
+            "-r", "out.bin", "-s", "0x1234", "-p", "1", "-f", "100.5", "-a", "1", "-t", "0", "-b",
+            "1", "-v", "10", "-m", "9", "-l", "8", "-n", "5000", "-d",
+        ]);
+        assert_eq!(args.receive_file.as_deref(), Some("out.bin"));
+        assert_eq!(args.serial_number, Some(0x1234));
+        assert_eq!(args.packing, Some(1));
+        assert_eq!(args.freq_mhz.as_deref(), Some("100.5"));
+        assert_eq!(args.sample_rate, Some(1));
+        assert_eq!(args.sample_type, Some(0));
+        assert_eq!(args.biast, Some(1));
+        assert_eq!(
+            (args.vga_gain, args.mixer_gain, args.lna_gain),
+            (Some(10), Some(9), Some(8))
+        );
+        assert_eq!(args.num_samples, Some(5000));
+        assert!(args.verbose);
+    }
+
+    #[test]
+    fn dash_h_is_sensitivity_gain_not_help() {
+        // C's -h is the sensitivity gain; help moved to --help.
+        let args = parse(&["-r", "f", "-h", "12"]);
+        assert_eq!(args.sensitivity_gain, Some(12));
+    }
+
+    #[test]
+    fn config_defaults_match_c_globals() {
+        let config = build_config(&parse(&["-r", "f"]), "20260101_000000").expect("config");
+        assert_eq!(config.freq_hz, DEFAULT_FREQ_HZ);
+        assert_eq!(config.sample_type, SampleType::Int16Iq);
+        assert_eq!(config.sample_rate_val, 0);
+        assert_eq!(
+            (config.vga_gain, config.mixer_gain, config.lna_gain),
+            (DEFAULT_VGA_IF_GAIN, DEFAULT_MIXER_GAIN, DEFAULT_LNA_GAIN)
+        );
+        assert!(!config.biast);
+        assert!(!config.packing && !config.call_set_packing);
+        assert!(!config.limit_num_samples);
+    }
+
+    #[test]
+    fn validation_rejects_out_of_range_values_in_c_order() {
+        let cases: &[(&[&str], &str)] = &[
+            (&["-r", "f", "-f", "2000"], "frequency_MHz"),
+            (&["-w", "-t", "5"], "RAW sampling mode"),
+            (&[], "you shall specify at least"),
+            (&["-r", "f", "-p", "2"], "packing out of range"),
+            (&["-r", "f", "-t", "6"], "sample_type out of range"),
+            (&["-r", "f", "-b", "2"], "biast_val out of range"),
+            (&["-r", "f", "-v", "16"], "vga_gain out of range"),
+            (&["-r", "f", "-m", "16"], "mixer_gain out of range"),
+            (&["-r", "f", "-l", "15"], "lna_gain out of range"),
+            (&["-r", "f", "-g", "22"], "linearity_gain out of range"),
+            (&["-r", "f", "-h", "22"], "sensitivity_gain out of range"),
+            (&["-r", "f", "-g", "1", "-h", "1"], "both set"),
+        ];
+        for (argv, expected) in cases {
+            let err = build_config(&parse(argv), "20260101_000000").expect_err(expected);
+            assert!(err.contains(expected), "{argv:?}: {err}");
+        }
+    }
+
+    #[test]
+    fn biast_does_not_imply_serial_open() {
+        // Deviation: C's -b case sets the serial_number flag (a
+        // copy-paste bug), silently switching a bare `-b 1` run to
+        // airspy_open_sn(0). Here -b only drives the bias tee.
+        let config =
+            build_config(&parse(&["-r", "f", "-b", "1"]), "20260101_000000").expect("config");
+        assert!(config.biast);
+        assert_eq!(config.serial_number, None);
+    }
+
+    #[test]
+    fn wav_mode_generates_c_filename() {
+        let config = build_config(&parse(&["-w", "-f", "100"]), "20261225_101112").expect("config");
+        assert!(config.receive_wav);
+        assert_eq!(config.path, "AirSpy_20261225_101112Z_100000kHz_IQ.wav");
+    }
+
+    #[test]
+    fn num_samples_limit_computes_byte_budget() {
+        // int16 IQ: 16 bits * 2 channels / 8 = 4 bytes per sample.
+        let config =
+            build_config(&parse(&["-r", "f", "-n", "1000"]), "20260101_000000").expect("config");
+        assert!(config.limit_num_samples);
+        assert_eq!(config.bytes_to_xfer, 4000);
+        let err = build_config(
+            &parse(&["-r", "f", "-n", "0x8000000000000000"]),
+            "20260101_000000",
+        )
+        .expect_err("max");
+        assert!(err.contains("num_samples must be less than"));
+    }
+}

--- a/crates/airspy-tools/src/wav.rs
+++ b/crates/airspy-tools/src/wav.rs
@@ -1,0 +1,231 @@
+//! WAV output support for `airspy_rx`, ported from the
+//! `t_wav_file_hdr` structures, static initializer, and end-of-main
+//! header rewrite in `airspy-tools/src/airspy_rx.c`.
+
+use libairspy_rs::commands::SampleType;
+
+/// `sizeof(t_wav_file_hdr)` — 12-byte RIFF header + 24-byte format
+/// chunk + 8-byte data-chunk header, no padding.
+pub const WAV_HEADER_LEN: usize = 44;
+
+/// The most data bytes a classic RIFF/WAV file can carry: the 32-bit
+/// size fields cap the whole file at `u32::MAX` bytes, header
+/// included. C wraps its `uint32_t` `ftell` position past 4 GiB and
+/// writes corrupt size fields; deviation: `-w` captures stop at this
+/// budget so the finalized header is always representable.
+pub const WAV_MAX_DATA_BYTES: u64 = u32::MAX as u64 - WAV_HEADER_LEN as u64;
+
+/// The WAV format-chunk fields selected by `-t` in `airspy_rx.c` `main()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WavParams {
+    /// `wFormatTag`: 1 = PCM, 3 = IEEE float.
+    pub format_tag: u16,
+    /// `wChannels`: 2 for IQ, 1 for real/raw.
+    pub channels: u16,
+    /// `wBitsPerSample`.
+    pub bits_per_sample: u16,
+}
+
+impl WavParams {
+    /// The `-t` switch mapping in `airspy_rx.c` `main()`. The RAW case
+    /// sets only bits (12) and channels (1) in C; the format tag
+    /// keeps the PCM default (RAW is rejected for WAV output anyway).
+    pub fn for_sample_type(sample_type: SampleType) -> Self {
+        match sample_type {
+            SampleType::Float32Iq => Self {
+                format_tag: 3,
+                channels: 2,
+                bits_per_sample: 32,
+            },
+            SampleType::Float32Real => Self {
+                format_tag: 3,
+                channels: 1,
+                bits_per_sample: 32,
+            },
+            SampleType::Int16Iq => Self {
+                format_tag: 1,
+                channels: 2,
+                bits_per_sample: 16,
+            },
+            SampleType::Int16Real | SampleType::Uint16Real => Self {
+                format_tag: 1,
+                channels: 1,
+                bits_per_sample: 16,
+            },
+            SampleType::Raw => Self {
+                format_tag: 1,
+                channels: 1,
+                bits_per_sample: 12,
+            },
+        }
+    }
+
+    /// `wav_nb_byte_per_sample` (`wBitsPerSample / 8`).
+    pub fn bytes_per_sample(&self) -> u16 {
+        self.bits_per_sample / 8
+    }
+
+    /// `wBlockAlign` (`wChannels * wBitsPerSample / 8`).
+    pub fn block_align(&self) -> u16 {
+        self.channels * (self.bits_per_sample / 8)
+    }
+}
+
+/// The initial 44-byte header written before streaming — C's static
+/// `wave_file_hdr` initializer: chunk IDs and the fixed fmt-chunk size
+/// present, every "to update later" field zero.
+pub fn wav_header_placeholder() -> [u8; WAV_HEADER_LEN] {
+    let mut bytes = [0u8; WAV_HEADER_LEN];
+    bytes[0..4].copy_from_slice(b"RIFF");
+    bytes[8..12].copy_from_slice(b"WAVE");
+    bytes[12..16].copy_from_slice(b"fmt ");
+    bytes[16..20].copy_from_slice(&16u32.to_le_bytes());
+    bytes[36..40].copy_from_slice(b"data");
+    bytes
+}
+
+/// The end-of-capture header rewrite in `airspy_rx.c` `main()`:
+/// `size = file_pos - 8`, `data.chunkSize = file_pos - sizeof(hdr)`,
+/// format fields from the `-t` selection.
+///
+/// Deviation: C writes `dwAvgBytesPerSec = dwSamplesPerSec *
+/// wav_nb_byte_per_sample`, dropping the channel count — half the
+/// true byte rate for 2-channel IQ captures. The WAV spec value is
+/// `dwSamplesPerSec * wBlockAlign`, written here.
+pub fn wav_header_finalized(
+    file_pos: u32,
+    params: &WavParams,
+    samples_per_sec: u32,
+) -> [u8; WAV_HEADER_LEN] {
+    let mut bytes = wav_header_placeholder();
+    bytes[4..8].copy_from_slice(&(file_pos.wrapping_sub(8)).to_le_bytes());
+    bytes[20..22].copy_from_slice(&params.format_tag.to_le_bytes());
+    bytes[22..24].copy_from_slice(&params.channels.to_le_bytes());
+    bytes[24..28].copy_from_slice(&samples_per_sec.to_le_bytes());
+    let avg_bytes_per_sec = samples_per_sec.wrapping_mul(u32::from(params.block_align()));
+    bytes[28..32].copy_from_slice(&avg_bytes_per_sec.to_le_bytes());
+    bytes[32..34].copy_from_slice(&params.block_align().to_le_bytes());
+    bytes[34..36].copy_from_slice(&params.bits_per_sample.to_le_bytes());
+    // WAV_HEADER_LEN is 44; the cast cannot truncate.
+    #[allow(clippy::cast_possible_truncation)]
+    let data_len = file_pos.wrapping_sub(WAV_HEADER_LEN as u32);
+    bytes[40..44].copy_from_slice(&data_len.to_le_bytes());
+    bytes
+}
+
+/// The `-w` automatic filename: `AirSpy_%sZ_%ukHz_IQ.wav` with the
+/// `%Y%m%d_%H%M%S` local time and `freq_hz / 1000` (`airspy_rx.c`
+/// `main()`).
+pub fn wav_filename(date_time: &str, freq_hz: u32) -> String {
+    format!("AirSpy_{date_time}Z_{}kHz_IQ.wav", freq_hz / 1000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wav_params_map_sample_types_like_c() {
+        // The -t switch cases in airspy_rx.c main(): format tag 3 is
+        // IEEE float, 1 is PCM.
+        let float_iq = WavParams::for_sample_type(SampleType::Float32Iq);
+        assert_eq!(
+            (
+                float_iq.format_tag,
+                float_iq.channels,
+                float_iq.bits_per_sample
+            ),
+            (3, 2, 32)
+        );
+        let float_real = WavParams::for_sample_type(SampleType::Float32Real);
+        assert_eq!(
+            (
+                float_real.format_tag,
+                float_real.channels,
+                float_real.bits_per_sample
+            ),
+            (3, 1, 32)
+        );
+        let int16_iq = WavParams::for_sample_type(SampleType::Int16Iq);
+        assert_eq!(
+            (
+                int16_iq.format_tag,
+                int16_iq.channels,
+                int16_iq.bits_per_sample
+            ),
+            (1, 2, 16)
+        );
+        let int16_real = WavParams::for_sample_type(SampleType::Int16Real);
+        assert_eq!((int16_real.channels, int16_real.bits_per_sample), (1, 16));
+        let uint16_real = WavParams::for_sample_type(SampleType::Uint16Real);
+        assert_eq!((uint16_real.channels, uint16_real.bits_per_sample), (1, 16));
+        // RAW: 12 bits, mono (the case 5 branch sets only these two).
+        let raw = WavParams::for_sample_type(SampleType::Raw);
+        assert_eq!((raw.channels, raw.bits_per_sample), (1, 12));
+    }
+
+    #[test]
+    fn wav_data_budget_keeps_sizes_representable() {
+        // A maximal capture finalizes to file_pos = u32::MAX with
+        // in-range RIFF and data sizes.
+        assert_eq!(
+            WAV_MAX_DATA_BYTES + WAV_HEADER_LEN as u64,
+            u64::from(u32::MAX)
+        );
+        let params = WavParams::for_sample_type(SampleType::Int16Iq);
+        #[allow(clippy::cast_possible_truncation)]
+        let bytes = wav_header_finalized(u32::MAX, &params, 2_500_000);
+        assert_eq!(bytes[4..8], (u32::MAX - 8).to_le_bytes());
+        assert_eq!(bytes[40..44], (u32::MAX - 44).to_le_bytes());
+    }
+
+    #[test]
+    fn wav_header_placeholder_matches_c_static_initializer() {
+        // wave_file_hdr's static initializer: chunk IDs and the fixed
+        // fmt-chunk size are set, every "to update later" field is 0.
+        let bytes = wav_header_placeholder();
+        assert_eq!(bytes.len(), WAV_HEADER_LEN);
+        assert_eq!(&bytes[0..4], b"RIFF");
+        assert_eq!(bytes[4..8], [0; 4]);
+        assert_eq!(&bytes[8..12], b"WAVE");
+        assert_eq!(&bytes[12..16], b"fmt ");
+        assert_eq!(bytes[16..20], 16u32.to_le_bytes());
+        assert_eq!(bytes[20..36], [0; 16]);
+        assert_eq!(&bytes[36..40], b"data");
+        assert_eq!(bytes[40..44], [0; 4]);
+    }
+
+    #[test]
+    fn wav_header_finalized_encodes_c_field_updates() {
+        // The end-of-main header rewrite in airspy_rx.c: size =
+        // file_pos - 8, data chunkSize = file_pos - sizeof(header),
+        // fmt fields from the -t selection.
+        let params = WavParams::for_sample_type(SampleType::Int16Iq);
+        let bytes = wav_header_finalized(10_044, &params, 2_500_000);
+        assert_eq!(bytes[4..8], 10_036u32.to_le_bytes());
+        assert_eq!(bytes[20..22], 1u16.to_le_bytes()); // wFormatTag
+        assert_eq!(bytes[22..24], 2u16.to_le_bytes()); // wChannels
+        assert_eq!(bytes[24..28], 2_500_000u32.to_le_bytes());
+        // dwAvgBytesPerSec — deviation: C writes dwSamplesPerSec *
+        // wav_nb_byte_per_sample (5_000_000 here), dropping the
+        // channel count; the WAV spec value is rate * block align.
+        assert_eq!(bytes[28..32], 10_000_000u32.to_le_bytes());
+        assert_eq!(bytes[32..34], 4u16.to_le_bytes()); // wBlockAlign
+        assert_eq!(bytes[34..36], 16u16.to_le_bytes()); // wBitsPerSample
+        assert_eq!(bytes[40..44], 10_000u32.to_le_bytes());
+    }
+
+    #[test]
+    fn wav_filename_matches_c_snprintf_format() {
+        // snprintf(path_file, ..., "AirSpy_%sZ_%ukHz_IQ.wav",
+        // date_time, freq_hz / 1000).
+        assert_eq!(
+            wav_filename("20261225_101112", 100_000_000),
+            "AirSpy_20261225_101112Z_100000kHz_IQ.wav"
+        );
+        assert_eq!(
+            wav_filename("20130101_000000", 900_000_000),
+            "AirSpy_20130101_000000Z_900000kHz_IQ.wav"
+        );
+    }
+}

--- a/crates/airspy-tools/src/wav.rs
+++ b/crates/airspy-tools/src/wav.rs
@@ -8,6 +8,47 @@ use libairspy_rs::commands::SampleType;
 /// chunk + 8-byte data-chunk header, no padding.
 pub const WAV_HEADER_LEN: usize = 44;
 
+/// `wFormatTag` for integer PCM — the "1=PCM8/16" comment on
+/// `t_FormatChunk` in `airspy_rx.c`.
+pub const FORMAT_TAG_PCM: u16 = 1;
+/// `wFormatTag` for IEEE float — the "3=Float32" comment on
+/// `t_FormatChunk` in `airspy_rx.c`.
+pub const FORMAT_TAG_IEEE_FLOAT: u16 = 3;
+
+/// The fixed `chunkSize` of the format chunk ("16 fixed" in
+/// `t_FormatChunk`, set in the `wave_file_hdr` initializer).
+const FMT_CHUNK_SIZE: u32 = 16;
+/// The RIFF `size` field excludes the 8-byte chunk id + size pair —
+/// C's `file_pos - 8` in the header rewrite.
+const RIFF_SIZE_EXCLUDED: u32 = 8;
+
+// Byte offsets of the packed t_wav_file_hdr fields (t_WAVRIFF_hdr,
+// then t_FormatChunk, then t_DataChunk — airspy_rx.c):
+/// `t_WAVRIFF_hdr.size`.
+const RIFF_SIZE_OFFSET: usize = 4;
+/// `t_WAVRIFF_hdr.riffType`.
+const RIFF_TYPE_OFFSET: usize = 8;
+/// `t_FormatChunk.chunkID`.
+const FMT_ID_OFFSET: usize = 12;
+/// `t_FormatChunk.chunkSize`.
+const FMT_SIZE_OFFSET: usize = 16;
+/// `t_FormatChunk.wFormatTag`.
+const FORMAT_TAG_OFFSET: usize = 20;
+/// `t_FormatChunk.wChannels`.
+const CHANNELS_OFFSET: usize = 22;
+/// `t_FormatChunk.dwSamplesPerSec`.
+const SAMPLES_PER_SEC_OFFSET: usize = 24;
+/// `t_FormatChunk.dwAvgBytesPerSec`.
+const AVG_BYTES_PER_SEC_OFFSET: usize = 28;
+/// `t_FormatChunk.wBlockAlign`.
+const BLOCK_ALIGN_OFFSET: usize = 32;
+/// `t_FormatChunk.wBitsPerSample`.
+const BITS_PER_SAMPLE_OFFSET: usize = 34;
+/// `t_DataChunk.chunkID`.
+const DATA_ID_OFFSET: usize = 36;
+/// `t_DataChunk.chunkSize`.
+const DATA_SIZE_OFFSET: usize = 40;
+
 /// The most data bytes a classic RIFF/WAV file can carry: the 32-bit
 /// size fields cap the whole file at `u32::MAX` bytes, header
 /// included. C wraps its `uint32_t` `ftell` position past 4 GiB and
@@ -33,27 +74,27 @@ impl WavParams {
     pub fn for_sample_type(sample_type: SampleType) -> Self {
         match sample_type {
             SampleType::Float32Iq => Self {
-                format_tag: 3,
+                format_tag: FORMAT_TAG_IEEE_FLOAT,
                 channels: 2,
                 bits_per_sample: 32,
             },
             SampleType::Float32Real => Self {
-                format_tag: 3,
+                format_tag: FORMAT_TAG_IEEE_FLOAT,
                 channels: 1,
                 bits_per_sample: 32,
             },
             SampleType::Int16Iq => Self {
-                format_tag: 1,
+                format_tag: FORMAT_TAG_PCM,
                 channels: 2,
                 bits_per_sample: 16,
             },
             SampleType::Int16Real | SampleType::Uint16Real => Self {
-                format_tag: 1,
+                format_tag: FORMAT_TAG_PCM,
                 channels: 1,
                 bits_per_sample: 16,
             },
             SampleType::Raw => Self {
-                format_tag: 1,
+                format_tag: FORMAT_TAG_PCM,
                 channels: 1,
                 bits_per_sample: 12,
             },
@@ -76,11 +117,11 @@ impl WavParams {
 /// present, every "to update later" field zero.
 pub fn wav_header_placeholder() -> [u8; WAV_HEADER_LEN] {
     let mut bytes = [0u8; WAV_HEADER_LEN];
-    bytes[0..4].copy_from_slice(b"RIFF");
-    bytes[8..12].copy_from_slice(b"WAVE");
-    bytes[12..16].copy_from_slice(b"fmt ");
-    bytes[16..20].copy_from_slice(&16u32.to_le_bytes());
-    bytes[36..40].copy_from_slice(b"data");
+    bytes[0..RIFF_SIZE_OFFSET].copy_from_slice(b"RIFF");
+    bytes[RIFF_TYPE_OFFSET..FMT_ID_OFFSET].copy_from_slice(b"WAVE");
+    bytes[FMT_ID_OFFSET..FMT_SIZE_OFFSET].copy_from_slice(b"fmt ");
+    bytes[FMT_SIZE_OFFSET..FORMAT_TAG_OFFSET].copy_from_slice(&FMT_CHUNK_SIZE.to_le_bytes());
+    bytes[DATA_ID_OFFSET..DATA_SIZE_OFFSET].copy_from_slice(b"data");
     bytes
 }
 
@@ -98,18 +139,23 @@ pub fn wav_header_finalized(
     samples_per_sec: u32,
 ) -> [u8; WAV_HEADER_LEN] {
     let mut bytes = wav_header_placeholder();
-    bytes[4..8].copy_from_slice(&(file_pos.wrapping_sub(8)).to_le_bytes());
-    bytes[20..22].copy_from_slice(&params.format_tag.to_le_bytes());
-    bytes[22..24].copy_from_slice(&params.channels.to_le_bytes());
-    bytes[24..28].copy_from_slice(&samples_per_sec.to_le_bytes());
+    let riff_size = file_pos.wrapping_sub(RIFF_SIZE_EXCLUDED);
+    bytes[RIFF_SIZE_OFFSET..RIFF_TYPE_OFFSET].copy_from_slice(&riff_size.to_le_bytes());
+    bytes[FORMAT_TAG_OFFSET..CHANNELS_OFFSET].copy_from_slice(&params.format_tag.to_le_bytes());
+    bytes[CHANNELS_OFFSET..SAMPLES_PER_SEC_OFFSET].copy_from_slice(&params.channels.to_le_bytes());
+    bytes[SAMPLES_PER_SEC_OFFSET..AVG_BYTES_PER_SEC_OFFSET]
+        .copy_from_slice(&samples_per_sec.to_le_bytes());
     let avg_bytes_per_sec = samples_per_sec.wrapping_mul(u32::from(params.block_align()));
-    bytes[28..32].copy_from_slice(&avg_bytes_per_sec.to_le_bytes());
-    bytes[32..34].copy_from_slice(&params.block_align().to_le_bytes());
-    bytes[34..36].copy_from_slice(&params.bits_per_sample.to_le_bytes());
+    bytes[AVG_BYTES_PER_SEC_OFFSET..BLOCK_ALIGN_OFFSET]
+        .copy_from_slice(&avg_bytes_per_sec.to_le_bytes());
+    bytes[BLOCK_ALIGN_OFFSET..BITS_PER_SAMPLE_OFFSET]
+        .copy_from_slice(&params.block_align().to_le_bytes());
+    bytes[BITS_PER_SAMPLE_OFFSET..DATA_ID_OFFSET]
+        .copy_from_slice(&params.bits_per_sample.to_le_bytes());
     // WAV_HEADER_LEN is 44; the cast cannot truncate.
     #[allow(clippy::cast_possible_truncation)]
     let data_len = file_pos.wrapping_sub(WAV_HEADER_LEN as u32);
-    bytes[40..44].copy_from_slice(&data_len.to_le_bytes());
+    bytes[DATA_SIZE_OFFSET..WAV_HEADER_LEN].copy_from_slice(&data_len.to_le_bytes());
     bytes
 }
 


### PR DESCRIPTION
## Summary

First M5 tool: the port of `airspy_rx.c` (1,115 lines — "the big one"), exercising the full library surface: open/open-by-serial, sample type, sample rate, frequency, all three gain modes, packing, bias-T, streaming callback, and stop/teardown.

**Layout**
- `airspy_tools::rx` (lib): all hardware-free logic, unit-tested — WAV header serialization (placeholder + finalized, byte-exact against the C struct layout), C `parse_u32`/`strtod`-prefix parse semantics, the `-n` byte-budget formula, index-or-literal sample-rate resolution, the automatic WAV filename, the 50-buffer EWMA rate tracker, per-block frame counting, and little-endian sample serialization.
- `airspy_rx` (bin): clap CLI mirroring the C flags exactly (`-h` is the sensitivity gain as in C — help moved to `--help`), C-ordered validation with C's stderr messages and `usage()` text, and the runtime sequence in C's exact order (set_freq after start_rx, bias-T always applied, gain failures print but don't abort, `-` writes to stdout, 16 KiB output buffering matching `setvbuf`).

## Deviations (upstream bugs fixed per project policy)

1. **`-b` copy-paste bug**: C's `case 'b'` sets `serial_number = true` instead of a bias-T flag, so a bare `-b 1` silently opens serial number 0. Here `-b` only drives the bias tee (regression-tested).
2. **`dwAvgBytesPerSec`**: C writes `rate × bytes_per_sample`, omitting the channel count — half the true byte rate for IQ WAVs. The WAV-spec value `rate × block_align` is written (tested).
3. **Unpacked RAW `-n` budget**: C computes the byte limit with the packed 12-bit figure regardless of packing, stopping unpacked RAW captures at 75% of the requested samples; the unpacked case uses 16 bits (tested).
4. **Signals**: C traps INT/ILL/FPE/SEGV/TERM/ABRT; only INT/TERM have a safe Rust equivalent (via `ctrlc`).

Faithfully kept: `u16` truncation/wrap semantics of C's parsers, the frequency `[24, 1900[` MHz check (max exclusive), the `>4 GiB` WAV size-field wrap (`ftell` → `uint32_t`), and the C `9.5f` dead store in the status loop is simply omitted.

## New dependencies

`chrono` (default-features off, `clock` only — WAV filename timestamp) and `ctrlc` (signal handler). `cargo deny` clean.

## Testing

23 new tests (16 lib + 7 bin: flag mirroring, C-order validation messages, defaults, the `-b` deviation, WAV filename, byte budget incl. the C wrapping overflow case). Full workspace: 142 tests, fmt/clippy (`-D warnings`, all features)/doc (`-D warnings`)/deny all clean. Smoke-tested the CLI error paths and exit codes without hardware; the streaming path itself is hardware-dependent and lands in M6 validation.

Closes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `airspy_rx` command-line tool for capturing Airspy samples to files or standard output.
  * Supports configurable frequency, sample rate, gain, sample format, serial device, bias-T, packing, verbosity, and sample limits.
  * Supports raw binary and SDR#-compatible WAV output with automatic filenames and finalized headers.
  * Added configuration validation, status reporting, graceful signal handling, and transfer-rate tracking.
  * Added reusable receive and WAV-processing capabilities for Airspy tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->