### PR TITLE
M5: airspy_si5351c + airspy_r820t (#28)

### DIFF
--- a/crates/airspy-tools/src/bin/airspy_r820t.rs
+++ b/crates/airspy-tools/src/bin/airspy_r820t.rs
@@ -1,0 +1,127 @@
+//! Port of `airspy_r820t.c`: read, write, and dump the R820T tuner
+//! registers, plus the `-c` default-mode register configuration.
+//! Output goes to stdout with the C tool's exact formats so the two
+//! are diffable.
+
+use airspy_tools::gpio_cli::{ReplayOutcome, open_from_matches};
+use airspy_tools::reg_cli::{
+    R820T_SPEC, RegReadScope, dump_all_registers, reg_command, reg_ops_from_matches, replay_reg_ops,
+};
+use libairspy_rs::{Device, Error};
+
+/// `CONF_R820T_START_REG` in `airspy_r820t.c`.
+const CONF_R820T_START_REG: u8 = 5;
+
+/// `conf_r820t` in `airspy_r820t.c` — the "default mode for test"
+/// register values for registers 5 through 31.
+const CONF_R820T: [u8; 27] = [
+    0x12, 0x32, 0x75, // 05 to 07
+    0xc0, 0x40, 0xd6, 0x6c, // 08 to 11
+    0x40, 0x63, 0x75, 0x68, // 12 to 15
+    0x6c, 0x83, 0x80, 0x00, // 16 to 19
+    0x0f, 0x00, 0xc0, 0x30, // 20 to 23
+    0x48, 0xcc, 0x60, 0x00, // 24 to 27
+    0x54, 0xae, 0x4a, 0xc0, // 28 to 31
+];
+
+/// The C tool's `usage()`.
+fn usage() {
+    println!("Usage:");
+    println!(
+        "\t-n, --register <n>: set register <n>[0,{}] for subsequent read/write operations",
+        R820T_SPEC.register_max
+    );
+    println!("\t-r, --read: read register specified by last -n argument, or all registers");
+    println!(
+        "\t-w, --write <v>: write register specified by last -n argument with value <v>[0,255]"
+    );
+    println!("\t-c, --config: configure registers to r820t default mode for test");
+    println!("\t[-s serial_number_64bits]: Open board with specified 64bits serial number.");
+    println!("\nExamples:");
+    println!("\t<command> -n 12 -r    # reads from register 12");
+    println!("\t<command> -r          # reads all registers");
+    println!("\t<command> -n 10 -w 22 # writes register 10 with 22 decimal");
+}
+
+/// `dump_register` in `airspy_r820t.c` (uppercase hex).
+fn dump_register(device: &Device, register: u8) -> Result<(), Error> {
+    match device.r820t_read(register) {
+        Ok(value) => {
+            println!("[{register:3}] -> 0x{value:02X}");
+            Ok(())
+        }
+        Err(err) => {
+            println!(
+                "airspy_r820t_read() failed: {} ({})",
+                err.name(),
+                err.code()
+            );
+            Err(err)
+        }
+    }
+}
+
+/// `write_register` in `airspy_r820t.c` (zero-padded uppercase hex).
+fn write_register(device: &Device, register: u8, value: u8) -> Result<(), Error> {
+    match device.r820t_write(register, value) {
+        Ok(()) => {
+            println!("0x{value:02X} -> [{register:3}]");
+            Ok(())
+        }
+        Err(err) => {
+            println!(
+                "airspy_r820t_write() failed: {} ({})",
+                err.name(),
+                err.code()
+            );
+            Err(err)
+        }
+    }
+}
+
+/// `configure_registers` in `airspy_r820t.c`: write the default
+/// table to registers 5..=31, printing each, stopping on failure.
+fn configure_registers(device: &Device) -> Result<(), Error> {
+    for (i, value) in CONF_R820T.iter().enumerate() {
+        #[allow(clippy::cast_possible_truncation)]
+        let register = CONF_R820T_START_REG + i as u8;
+        write_register(device, register, *value)?;
+    }
+    Ok(())
+}
+
+fn main() {
+    let matches = reg_command(
+        "airspy_r820t",
+        "Read and write the Airspy R820T tuner registers",
+        false,
+    )
+    .get_matches();
+
+    let Some(device) = open_from_matches(&matches) else {
+        usage();
+        std::process::exit(1);
+    };
+
+    let ops = reg_ops_from_matches(&matches);
+    let outcome = replay_reg_ops(
+        R820T_SPEC,
+        &ops,
+        &mut |scope| match scope {
+            RegReadScope::All => dump_all_registers(R820T_SPEC.register_max, &mut |register| {
+                dump_register(&device, register)
+            }),
+            RegReadScope::Single(register) => dump_register(&device, register),
+        },
+        &mut |register, value| write_register(&device, register, value),
+        &mut || configure_registers(&device),
+        &mut |line| println!("{line}"),
+    );
+
+    if outcome != ReplayOutcome::Completed {
+        usage();
+    }
+    // Deviation: C exits 0 even when an operation failed; a failed
+    // operation surfaces as status 1 here.
+    std::process::exit(i32::from(outcome == ReplayOutcome::Failed));
+}

--- a/crates/airspy-tools/src/bin/airspy_si5351c.rs
+++ b/crates/airspy-tools/src/bin/airspy_si5351c.rs
@@ -1,0 +1,164 @@
+//! Port of `airspy_si5351c.c`: read, write, and dump the si5351c
+//! clock generator's registers, plus the `-c` multisynth
+//! configuration decode. Output goes to stdout with the C tool's
+//! exact formats so the two are diffable.
+
+use airspy_tools::gpio_cli::{ReplayOutcome, open_from_matches};
+use airspy_tools::reg_cli::{
+    DIV_LUT, RegReadScope, SI5351C_SPEC, dump_all_registers, ms_int_output_mhz, ms_output_mhz,
+    ms_params, reg_command, reg_ops_from_matches, replay_reg_ops,
+};
+use libairspy_rs::{Device, Error};
+
+/// `reg_base = 42 + (ms_number * 8)` in `dump_multisynth_config`.
+const MS_FRACTIONAL_REG_BASE: u8 = 42;
+/// The MS6/MS7 register base (`reg_base = 90`).
+const MS_INTEGER_REG_BASE: u8 = 90;
+
+/// The C tool's `usage()` (note its leading blank line).
+fn usage() {
+    println!("\nUsage:");
+    println!("\t-c, --config: print textual configuration information");
+    println!("\t-n, --register <n>: set register number for subsequent read/write operations");
+    println!("\t-r, --read: read register specified by last -n argument, or all registers");
+    println!("\t-w, --write <v>: write register specified by last -n argument with value <v>");
+    println!("\t[-s serial_number_64bits]: Open board with specified 64bits serial number.");
+    println!("\nExamples:");
+    println!("\t<command> -n 12 -r    # reads from register 12");
+    println!("\t<command> -r          # reads all registers");
+    println!("\t<command> -n 10 -w 22 # writes register 10 with 22 decimal");
+}
+
+/// `dump_register` in `airspy_si5351c.c` (lowercase hex).
+fn dump_register(device: &Device, register: u8) -> Result<(), Error> {
+    match device.si5351c_read(register) {
+        Ok(value) => {
+            println!("[{register:3}] -> 0x{value:02x}");
+            Ok(())
+        }
+        Err(err) => {
+            println!(
+                "airspy_si5351c_read() failed: {} ({})",
+                err.name(),
+                err.code()
+            );
+            Err(err)
+        }
+    }
+}
+
+/// `write_register` in `airspy_si5351c.c` — note C's `%2x`
+/// (space-padded, lowercase, no `0` fill).
+fn write_register(device: &Device, register: u8, value: u8) -> Result<(), Error> {
+    match device.si5351c_write(register, value) {
+        Ok(()) => {
+            println!("0x{value:2x} -> [{register:3}]");
+            Ok(())
+        }
+        Err(err) => {
+            println!(
+                "airspy_si5351c_write() failed: {} ({})",
+                err.name(),
+                err.code()
+            );
+            Err(err)
+        }
+    }
+}
+
+/// `dump_multisynth_config` in `airspy_si5351c.c`. A failed register
+/// read returns silently mid-print exactly as C does (the pending
+/// `MS%d:` stays unterminated before `usage()`).
+fn dump_multisynth_config(device: &Device, ms_number: u8) -> Result<(), Error> {
+    print!("MS{ms_number}:");
+    let r_div;
+    if ms_number < 6 {
+        let reg_base = MS_FRACTIONAL_REG_BASE + ms_number * 8;
+        let mut parameters = [0u8; 8];
+        for (i, slot) in parameters.iter_mut().enumerate() {
+            #[allow(clippy::cast_possible_truncation)]
+            let register = reg_base + i as u8;
+            *slot = device.si5351c_read(register)?;
+        }
+        let params = ms_params(&parameters);
+        r_div = params.r_div;
+        println!("\tp1 = {}", params.p1);
+        println!("\tp2 = {}", params.p2);
+        println!("\tp3 = {}", params.p3);
+        if params.p3 != 0 {
+            println!("\tOutput (800Mhz PLL): {:.10} Mhz", ms_output_mhz(&params));
+        }
+    } else {
+        // MS6 and 7 are integer only.
+        let mut parameters = [0u8; 3];
+        for (i, slot) in parameters.iter_mut().enumerate() {
+            #[allow(clippy::cast_possible_truncation)]
+            let register = MS_INTEGER_REG_BASE + i as u8;
+            *slot = device.si5351c_read(register)?;
+        }
+        r_div = if ms_number == 6 {
+            u32::from(parameters[2] & 0x7)
+        } else {
+            u32::from((parameters[2] & 0x70) >> 4)
+        };
+        let parms = if ms_number == 6 {
+            parameters[0]
+        } else {
+            parameters[1]
+        };
+        println!("\tp1_int = {parms}");
+        if parms != 0 {
+            println!(
+                "\tOutput (800Mhz PLL): {:.10} Mhz",
+                f64::from(ms_int_output_mhz(parms, r_div))
+            );
+        }
+    }
+    println!("\toutput divider = {}", DIV_LUT[r_div as usize]);
+    Ok(())
+}
+
+/// `dump_configuration` in `airspy_si5351c.c`: all eight multisynth
+/// blocks, stopping at the first failure.
+fn dump_configuration(device: &Device) -> Result<(), Error> {
+    for ms_number in 0..8 {
+        dump_multisynth_config(device, ms_number)?;
+    }
+    Ok(())
+}
+
+fn main() {
+    let matches = reg_command(
+        "airspy_si5351c",
+        "Read and write the Airspy si5351c clock generator registers",
+        true,
+    )
+    .get_matches();
+
+    let Some(device) = open_from_matches(&matches) else {
+        usage();
+        std::process::exit(1);
+    };
+
+    let ops = reg_ops_from_matches(&matches);
+    let outcome = replay_reg_ops(
+        SI5351C_SPEC,
+        &ops,
+        &mut |scope| match scope {
+            RegReadScope::All => dump_all_registers(SI5351C_SPEC.register_max, &mut |register| {
+                dump_register(&device, register)
+            }),
+            RegReadScope::Single(register) => dump_register(&device, register),
+        },
+        &mut |register, value| write_register(&device, register, value),
+        &mut || dump_configuration(&device),
+        &mut |line| println!("{line}"),
+    );
+
+    if outcome != ReplayOutcome::Completed {
+        usage();
+    }
+    // Deviation: C exits 0 even when an operation failed; a failed
+    // operation surfaces as status 1 here.
+    std::process::exit(i32::from(outcome == ReplayOutcome::Failed));
+}

--- a/crates/airspy-tools/src/lib.rs
+++ b/crates/airspy-tools/src/lib.rs
@@ -6,6 +6,7 @@
 #![warn(missing_docs)]
 
 pub mod gpio_cli;
+pub mod reg_cli;
 pub mod rx;
 pub mod rx_cli;
 pub mod wav;

--- a/crates/airspy-tools/src/reg_cli.rs
+++ b/crates/airspy-tools/src/reg_cli.rs
@@ -93,42 +93,12 @@ pub fn replay_reg_ops(
     let mut outcome = ReplayOutcome::NoOps;
     for op in ops {
         let ok = match op {
-            RegOp::Register(raw) => {
-                if let Some(value) = parse_u8(raw).filter(|v| *v <= spec.register_max) {
-                    // C's case 'n' stores the parse result, so a
-                    // bare -n suppresses usage().
-                    register = Some(value);
-                    outcome = ReplayOutcome::Completed;
-                    true
-                } else {
-                    if spec.print_messages {
-                        out(format!(
-                            "Error parameter -n shall be between 0 and {}",
-                            spec.register_max
-                        ));
-                    }
-                    false
-                }
-            }
+            RegOp::Register(raw) => latch_register(spec, raw, &mut register, &mut outcome, out),
             RegOp::Read => {
                 let scope = register.map_or(RegReadScope::All, RegReadScope::Single);
                 run_operation(&read(scope), &mut outcome)
             }
-            RegOp::Write(raw) => match (parse_u8(raw), register) {
-                (Some(value), Some(register)) => {
-                    run_operation(&write(register, value), &mut outcome)
-                }
-                (None, _) => {
-                    if spec.print_messages {
-                        out("Error parameter -w shall be between 0 and 255".into());
-                    }
-                    false
-                }
-                _ => {
-                    out("error: -w requires -n".into());
-                    false
-                }
-            },
+            RegOp::Write(raw) => write_latched(spec, raw, register, &mut outcome, write, out),
             RegOp::Config => run_operation(&config(), &mut outcome),
         };
         if !ok {
@@ -136,6 +106,60 @@ pub fn replay_reg_ops(
         }
     }
     outcome
+}
+
+/// The shared body of C's `case 'n'`: parse, range-check per the
+/// spec, latch on success — and store the parse result in the
+/// outcome, so a bare `-n` suppresses `usage()` just as C's `result`
+/// variable does. The r820t spec prints C's range message; the
+/// si5351c spec fails silently.
+fn latch_register(
+    spec: RegToolSpec,
+    raw: &str,
+    register: &mut Option<u8>,
+    outcome: &mut ReplayOutcome,
+    out: &mut impl FnMut(String),
+) -> bool {
+    if let Some(value) = parse_u8(raw).filter(|v| *v <= spec.register_max) {
+        *register = Some(value);
+        *outcome = ReplayOutcome::Completed;
+        true
+    } else {
+        if spec.print_messages {
+            out(format!(
+                "Error parameter -n shall be between 0 and {}",
+                spec.register_max
+            ));
+        }
+        false
+    }
+}
+
+/// The shared body of C's `case 'w'`: parse the value (r820t prints
+/// C's 0..255 message on failure, si5351c is silent) and write to
+/// the latched register — requiring one (deviation: C writes its
+/// default/sentinel register on the wire).
+fn write_latched(
+    spec: RegToolSpec,
+    raw: &str,
+    register: Option<u8>,
+    outcome: &mut ReplayOutcome,
+    write: &mut impl FnMut(u8, u8) -> Result<(), Error>,
+    out: &mut impl FnMut(String),
+) -> bool {
+    match (parse_u8(raw), register) {
+        (Some(value), Some(register)) => run_operation(&write(register, value), outcome),
+        (None, _) => {
+            if spec.print_messages {
+                out("Error parameter -w shall be between 0 and 255".into());
+            }
+            false
+        }
+        _ => {
+            out("error: -w requires -n".into());
+            false
+        }
+    }
 }
 
 /// The success/failure tail shared by the operation arms: mark
@@ -152,6 +176,13 @@ fn run_operation(result: &Result<(), Error>, outcome: &mut ReplayOutcome) -> boo
 /// `div_lut` in `dump_multisynth_config` (`airspy_si5351c.c`) — the
 /// output-divider power-of-two table.
 pub const DIV_LUT: [u32; 8] = [1, 2, 4, 8, 16, 32, 64, 128];
+
+/// The `(double)800` PLL frequency literal in the MS0–MS5 output
+/// formula (`dump_multisynth_config`, `airspy_si5351c.c`).
+const PLL_FREQ_MHZ: f64 = 800.0;
+/// The `800.0f` literal in the MS6/MS7 float formula — C keeps this
+/// path in single precision, so the constant stays f32.
+const PLL_FREQ_MHZ_F32: f32 = 800.0;
 
 /// The decoded multisynth parameters from `dump_multisynth_config`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -189,14 +220,14 @@ pub fn ms_output_mhz(params: &MsParams) -> f64 {
         + f64::from(params.p2)
         + f64::from(512 * params.p3))
         / f64::from(128 * params.p3);
-    (800.0 / divider) / f64::from(DIV_LUT[params.r_div as usize])
+    (PLL_FREQ_MHZ / divider) / f64::from(DIV_LUT[params.r_div as usize])
 }
 
 /// The MS6/MS7 integer output print: `(800.0f / parms) /
 /// div_lut[r_div]` — float math in C, kept in f32.
 #[allow(clippy::cast_precision_loss)]
 pub fn ms_int_output_mhz(parms: u8, r_div: u32) -> f32 {
-    (800.0f32 / f32::from(parms)) / DIV_LUT[r_div as usize] as f32
+    (PLL_FREQ_MHZ_F32 / f32::from(parms)) / DIV_LUT[r_div as usize] as f32
 }
 
 /// The shared clap command for both register tools — the C
@@ -336,6 +367,25 @@ mod tests {
             reg_command("t", "t", true)
                 .try_get_matches_from(["t", "--serial", "0x1"])
                 .is_ok()
+        );
+    }
+
+    #[test]
+    fn repeated_flag_occurrences_keep_their_indices() {
+        // -r and -c are zero-value appends so every occurrence keeps
+        // its own clap index; interleavings replay in order.
+        let matches = reg_command("t", "t", true)
+            .try_get_matches_from(["t", "-r", "-c", "-n", "5", "-r", "-c"])
+            .expect("parse");
+        assert_eq!(
+            reg_ops_from_matches(&matches),
+            [
+                RegOp::Read,
+                RegOp::Config,
+                RegOp::Register("5".into()),
+                RegOp::Read,
+                RegOp::Config,
+            ]
         );
     }
 

--- a/crates/airspy-tools/src/reg_cli.rs
+++ b/crates/airspy-tools/src/reg_cli.rs
@@ -1,0 +1,533 @@
+//! Shared engine for the `airspy_si5351c` and `airspy_r820t`
+//! register tools, ported from `airspy-tools/src/airspy_si5351c.c`
+//! and `airspy_r820t.c`: the order-sensitive `-n`/`-r`/`-w`/`-c`
+//! replay of the C getopt loops, the break-on-error register dump,
+//! and the si5351c multisynth parameter math. Device-facing print
+//! formats stay in the binaries; everything here is hardware-free
+//! and unit-tested.
+
+use libairspy_rs::Error;
+
+use crate::gpio_cli::{ReplayOutcome, parse_u8};
+
+/// Per-tool differences between the two C register tools.
+#[derive(Debug, Clone, Copy)]
+pub struct RegToolSpec {
+    /// `REGISTER_NUM_MAX` (31) in `airspy_r820t.c`; the si5351c tool
+    /// accepts every 8-bit register (`dump_registers` walks 0..256).
+    pub register_max: u8,
+    /// `airspy_r820t.c` prints range messages for `-n` and `-w`;
+    /// `airspy_si5351c.c`'s `parse_int` failures are silent (the
+    /// loop just breaks into `usage()`).
+    pub print_messages: bool,
+}
+
+/// `airspy_r820t.c`'s behavior.
+pub const R820T_SPEC: RegToolSpec = RegToolSpec {
+    register_max: 31,
+    print_messages: true,
+};
+
+/// `airspy_si5351c.c`'s behavior.
+pub const SI5351C_SPEC: RegToolSpec = RegToolSpec {
+    register_max: 255,
+    print_messages: false,
+};
+
+/// One replayed occurrence of the C getopt loop's options, in
+/// command-line order. Values stay raw strings — C parses each at
+/// its own loop iteration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegOp {
+    /// `-n <register>` — latch the register for later operations.
+    Register(String),
+    /// `-r` — dump the latched register, or all registers.
+    Read,
+    /// `-w <value>` — write the latched register.
+    Write(String),
+    /// `-c` — the tool-specific configuration operation.
+    Config,
+}
+
+/// What a `-r` acts on: no register latched yet → the full dump.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegReadScope {
+    /// `dump_registers` — every register up to the tool's maximum.
+    All,
+    /// `dump_register` — one register.
+    Single(u8),
+}
+
+/// `dump_registers` in both C tools: walk `0..=register_max` and
+/// stop at the first failed read (unlike the GPIO dump, which
+/// continues through failures).
+pub fn dump_all_registers(
+    register_max: u8,
+    per_register: &mut impl FnMut(u8) -> Result<(), Error>,
+) -> Result<(), Error> {
+    for register in 0..=register_max {
+        per_register(register)?;
+    }
+    Ok(())
+}
+
+/// Replay the C getopt loop: `-n` latches the register, `-r`/`-w`/
+/// `-c` act immediately, and the first failure stops the loop (no
+/// "argument error" line — the register tools' helpers print their
+/// own failures, then `usage()` follows). `out` receives the range
+/// messages when the spec prints them.
+///
+/// Deviations: a `-w` without `-n` errors instead of writing C's
+/// default/sentinel register (0 for si5351c, 255 for r820t), and
+/// out-of-range si5351c values reject instead of C's silent
+/// `(uint8_t)` truncation in `parse_int`.
+pub fn replay_reg_ops(
+    spec: RegToolSpec,
+    ops: &[RegOp],
+    read: &mut impl FnMut(RegReadScope) -> Result<(), Error>,
+    write: &mut impl FnMut(u8, u8) -> Result<(), Error>,
+    config: &mut impl FnMut() -> Result<(), Error>,
+    out: &mut impl FnMut(String),
+) -> ReplayOutcome {
+    let mut register: Option<u8> = None;
+    let mut outcome = ReplayOutcome::NoOps;
+    for op in ops {
+        let ok = match op {
+            RegOp::Register(raw) => {
+                if let Some(value) = parse_u8(raw).filter(|v| *v <= spec.register_max) {
+                    // C's case 'n' stores the parse result, so a
+                    // bare -n suppresses usage().
+                    register = Some(value);
+                    outcome = ReplayOutcome::Completed;
+                    true
+                } else {
+                    if spec.print_messages {
+                        out(format!(
+                            "Error parameter -n shall be between 0 and {}",
+                            spec.register_max
+                        ));
+                    }
+                    false
+                }
+            }
+            RegOp::Read => {
+                let scope = register.map_or(RegReadScope::All, RegReadScope::Single);
+                run_operation(&read(scope), &mut outcome)
+            }
+            RegOp::Write(raw) => match (parse_u8(raw), register) {
+                (Some(value), Some(register)) => {
+                    run_operation(&write(register, value), &mut outcome)
+                }
+                (None, _) => {
+                    if spec.print_messages {
+                        out("Error parameter -w shall be between 0 and 255".into());
+                    }
+                    false
+                }
+                _ => {
+                    out("error: -w requires -n".into());
+                    false
+                }
+            },
+            RegOp::Config => run_operation(&config(), &mut outcome),
+        };
+        if !ok {
+            return ReplayOutcome::Failed;
+        }
+    }
+    outcome
+}
+
+/// The success/failure tail shared by the operation arms: mark
+/// progress or stop (the helpers have already printed any failure).
+fn run_operation(result: &Result<(), Error>, outcome: &mut ReplayOutcome) -> bool {
+    if result.is_ok() {
+        *outcome = ReplayOutcome::Completed;
+        true
+    } else {
+        false
+    }
+}
+
+/// `div_lut` in `dump_multisynth_config` (`airspy_si5351c.c`) — the
+/// output-divider power-of-two table.
+pub const DIV_LUT: [u32; 8] = [1, 2, 4, 8, 16, 32, 64, 128];
+
+/// The decoded multisynth parameters from `dump_multisynth_config`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MsParams {
+    /// The 18-bit `p1` field.
+    pub p1: u32,
+    /// The 20-bit `p2` field.
+    pub p2: u32,
+    /// The 20-bit `p3` field.
+    pub p3: u32,
+    /// The 3-bit output-divider index into [`DIV_LUT`].
+    pub r_div: u32,
+}
+
+/// The MS0–MS5 bit unpacking in `dump_multisynth_config`
+/// (`airspy_si5351c.c`): `p1` spans registers 2..5, `p2` the low
+/// nibble of 5 plus 6..8, `p3` the high nibble of 5 plus 0..2, and
+/// `r_div` bits 4..6 of register 2.
+pub fn ms_params(parameters: &[u8; 8]) -> MsParams {
+    let p = parameters.map(u32::from);
+    MsParams {
+        p1: ((p[2] & 0x03) << 16) | (p[3] << 8) | p[4],
+        p2: ((p[5] & 0x0F) << 16) | (p[6] << 8) | p[7],
+        p3: ((p[5] & 0xF0) << 12) | (p[0] << 8) | p[1],
+        r_div: (p[2] >> 4) & 0x7,
+    }
+}
+
+/// The fractional output frequency print in `dump_multisynth_config`:
+/// `((double)800 / (((double)p1*p3 + p2 + 512*p3) / (double)(128*p3)))
+/// / div_lut[r_div]`, with `512*p3` computed in integer arithmetic
+/// first exactly as C does.
+pub fn ms_output_mhz(params: &MsParams) -> f64 {
+    let divider = (f64::from(params.p1) * f64::from(params.p3)
+        + f64::from(params.p2)
+        + f64::from(512 * params.p3))
+        / f64::from(128 * params.p3);
+    (800.0 / divider) / f64::from(DIV_LUT[params.r_div as usize])
+}
+
+/// The MS6/MS7 integer output print: `(800.0f / parms) /
+/// div_lut[r_div]` — float math in C, kept in f32.
+#[allow(clippy::cast_precision_loss)]
+pub fn ms_int_output_mhz(parms: u8, r_div: u32) -> f32 {
+    (800.0f32 / f32::from(parms)) / DIV_LUT[r_div as usize] as f32
+}
+
+/// The shared clap command for both register tools — the C
+/// `getopt_long(argc, argv, "cn:rw:s:", long_options, ...)` table.
+/// `serial_long` mirrors the C difference: `airspy_si5351c.c` lists
+/// a `--serial` long option, `airspy_r820t.c` has only `-s`.
+pub fn reg_command(name: &'static str, about: &'static str, serial_long: bool) -> clap::Command {
+    let mut serial = clap::Arg::new("serial")
+        .short('s')
+        .value_name("serial_number_64bits")
+        .value_parser(crate::parse_u64)
+        .help("Open board with specified 64bits serial number");
+    if serial_long {
+        serial = serial.long("serial");
+    }
+    clap::Command::new(name)
+        .about(about)
+        .disable_help_flag(true)
+        .arg(
+            clap::Arg::new("help")
+                .long("help")
+                .action(clap::ArgAction::Help)
+                .help("Print help"),
+        )
+        .arg(
+            // Zero-value append so every occurrence keeps its index.
+            clap::Arg::new("config")
+                .short('c')
+                .long("config")
+                .action(clap::ArgAction::Append)
+                .num_args(0)
+                .default_missing_value("c")
+                .help("the tool-specific configuration operation"),
+        )
+        .arg(
+            clap::Arg::new("register")
+                .short('n')
+                .long("register")
+                .value_name("n")
+                .action(clap::ArgAction::Append)
+                .help("set register number for subsequent read/write operations"),
+        )
+        .arg(
+            clap::Arg::new("read")
+                .short('r')
+                .long("read")
+                .action(clap::ArgAction::Append)
+                .num_args(0)
+                .default_missing_value("r")
+                .help("read register specified by last -n argument, or all registers"),
+        )
+        .arg(
+            clap::Arg::new("write")
+                .short('w')
+                .long("write")
+                .value_name("v")
+                .action(clap::ArgAction::Append)
+                .help("write register specified by last -n argument with value <v>"),
+        )
+        .arg(serial)
+}
+
+/// Recover the C getopt loop's op sequence in command-line order
+/// (clap argument indices), like the GPIO tools do.
+pub fn reg_ops_from_matches(matches: &clap::ArgMatches) -> Vec<RegOp> {
+    let mut ops: Vec<(usize, RegOp)> = Vec::new();
+    for (id, make) in [
+        ("register", RegOp::Register as fn(String) -> RegOp),
+        ("write", RegOp::Write as fn(String) -> RegOp),
+    ] {
+        if let (Some(values), Some(indices)) =
+            (matches.get_many::<String>(id), matches.indices_of(id))
+        {
+            ops.extend(indices.zip(values).map(|(i, v)| (i, make(v.clone()))));
+        }
+    }
+    for (id, op) in [("read", RegOp::Read), ("config", RegOp::Config)] {
+        if let Some(indices) = matches.indices_of(id) {
+            ops.extend(indices.map(|i| (i, op.clone())));
+        }
+    }
+    ops.sort_by_key(|(i, _)| *i);
+    ops.into_iter().map(|(_, op)| op).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libairspy_rs::Error;
+
+    /// Recording harness for one tool spec.
+    fn run(spec: RegToolSpec, ops: &[RegOp]) -> (ReplayOutcome, Vec<String>, Vec<String>) {
+        let log = std::cell::RefCell::new(Vec::new());
+        let mut out = Vec::new();
+        let outcome = replay_reg_ops(
+            spec,
+            ops,
+            &mut |scope| {
+                log.borrow_mut().push(format!("read {scope:?}"));
+                Ok(())
+            },
+            &mut |register, value| {
+                log.borrow_mut().push(format!("write {register} {value}"));
+                Ok(())
+            },
+            &mut || {
+                log.borrow_mut().push("config".into());
+                Ok(())
+            },
+            &mut |line| out.push(line),
+        );
+        (outcome, log.into_inner(), out)
+    }
+
+    #[test]
+    fn reg_ops_recover_command_line_order() {
+        let matches = reg_command("t", "t", true)
+            .try_get_matches_from(["t", "-n", "10", "-w", "22", "-c", "-n", "12", "-r"])
+            .expect("parse");
+        assert_eq!(
+            reg_ops_from_matches(&matches),
+            [
+                RegOp::Register("10".into()),
+                RegOp::Write("22".into()),
+                RegOp::Config,
+                RegOp::Register("12".into()),
+                RegOp::Read,
+            ]
+        );
+        // r820t has no --serial long option; si5351c does.
+        assert!(
+            reg_command("t", "t", false)
+                .try_get_matches_from(["t", "--serial", "0x1"])
+                .is_err()
+        );
+        assert!(
+            reg_command("t", "t", true)
+                .try_get_matches_from(["t", "--serial", "0x1"])
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn specs_match_c_tools() {
+        // airspy_r820t.c: REGISTER_NUM_MAX 31, range and -w messages;
+        // airspy_si5351c.c: all 256 registers, silent parse failures.
+        assert_eq!(
+            (R820T_SPEC.register_max, R820T_SPEC.print_messages),
+            (31, true)
+        );
+        assert_eq!(
+            (SI5351C_SPEC.register_max, SI5351C_SPEC.print_messages),
+            (255, false)
+        );
+    }
+
+    #[test]
+    fn read_uses_latched_register_or_dumps_all() {
+        let (o, log, _) = run(R820T_SPEC, &[RegOp::Read]);
+        assert_eq!(o, ReplayOutcome::Completed);
+        assert_eq!(log, ["read All"]);
+
+        let (_, log, _) = run(
+            R820T_SPEC,
+            &[RegOp::Register("12".into()), RegOp::Read, RegOp::Read],
+        );
+        assert_eq!(log, ["read Single(12)", "read Single(12)"]);
+    }
+
+    #[test]
+    fn ops_replay_in_command_line_order() {
+        let (o, log, _) = run(
+            SI5351C_SPEC,
+            &[
+                RegOp::Register("10".into()),
+                RegOp::Write("22".into()),
+                RegOp::Config,
+                RegOp::Register("12".into()),
+                RegOp::Read,
+            ],
+        );
+        assert_eq!(o, ReplayOutcome::Completed);
+        assert_eq!(log, ["write 10 22", "config", "read Single(12)"]);
+    }
+
+    #[test]
+    fn r820t_register_range_error_prints_c_message() {
+        // airspy_r820t.c case 'n': out-of-range prints the message,
+        // sets result = OTHER, and the loop breaks.
+        let (o, log, out) = run(R820T_SPEC, &[RegOp::Register("32".into()), RegOp::Read]);
+        assert_eq!(o, ReplayOutcome::Failed);
+        assert!(log.is_empty());
+        assert_eq!(out, ["Error parameter -n shall be between 0 and 31"]);
+
+        let (_, _, out) = run(R820T_SPEC, &[RegOp::Register("abc".into())]);
+        assert_eq!(out, ["Error parameter -n shall be between 0 and 31"]);
+    }
+
+    #[test]
+    fn r820t_write_parse_error_prints_c_message() {
+        // airspy_r820t.c case 'w': parse failure prints the 0..255
+        // message.
+        let (o, _, out) = run(
+            R820T_SPEC,
+            &[RegOp::Register("5".into()), RegOp::Write("256".into())],
+        );
+        assert_eq!(o, ReplayOutcome::Failed);
+        assert_eq!(out, ["Error parameter -w shall be between 0 and 255"]);
+    }
+
+    #[test]
+    fn si5351c_parse_failures_are_silent_and_reject_truncation() {
+        // airspy_si5351c.c's parse_int has no range check and casts
+        // long to uint8 (-n 300 would poke register 44); deviation:
+        // out-of-range rejects, silently like C's parse failures.
+        let (o, log, out) = run(SI5351C_SPEC, &[RegOp::Register("300".into()), RegOp::Read]);
+        assert_eq!(o, ReplayOutcome::Failed);
+        assert!(log.is_empty());
+        assert!(out.is_empty());
+
+        let (o, _, out) = run(
+            SI5351C_SPEC,
+            &[RegOp::Register("10".into()), RegOp::Write("abc".into())],
+        );
+        assert_eq!(o, ReplayOutcome::Failed);
+        assert!(out.is_empty());
+
+        // Register 255 is a valid si5351c register (no C range check).
+        let (o, log, _) = run(SI5351C_SPEC, &[RegOp::Register("255".into()), RegOp::Read]);
+        assert_eq!(o, ReplayOutcome::Completed);
+        assert_eq!(log, ["read Single(255)"]);
+    }
+
+    #[test]
+    fn write_requires_register_selection() {
+        // Deviation: without -n, C writes register 255 (r820t's
+        // REGISTER_INVALID sentinel) or register 0 (si5351c's
+        // default) on the wire.
+        for spec in [R820T_SPEC, SI5351C_SPEC] {
+            let (o, log, out) = run(spec, &[RegOp::Write("1".into())]);
+            assert_eq!(o, ReplayOutcome::Failed);
+            assert!(log.is_empty());
+            assert_eq!(out, ["error: -w requires -n"]);
+        }
+    }
+
+    #[test]
+    fn bare_register_suppresses_usage_and_no_ops_reports_noops() {
+        // C's case 'n' stores the parse result, so a bare -n ends
+        // with SUCCESS; no options at all leaves AIRSPY_ERROR_OTHER.
+        let (o, log, _) = run(R820T_SPEC, &[RegOp::Register("3".into())]);
+        assert_eq!(o, ReplayOutcome::Completed);
+        assert!(log.is_empty());
+
+        let (o, _, _) = run(R820T_SPEC, &[]);
+        assert_eq!(o, ReplayOutcome::NoOps);
+    }
+
+    #[test]
+    fn failed_operations_stop_without_argument_error_line() {
+        // Unlike the GPIO tools, the register tools print no
+        // "argument error" line — the dump/write helpers already
+        // printed, and the loop just breaks into usage().
+        let mut out = Vec::new();
+        let outcome = replay_reg_ops(
+            R820T_SPEC,
+            &[RegOp::Read, RegOp::Read],
+            &mut |_| Err(Error::NotFound),
+            &mut |_, _| Ok(()),
+            &mut || Ok(()),
+            &mut |line| out.push(line),
+        );
+        assert_eq!(outcome, ReplayOutcome::Failed);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn dump_all_breaks_on_first_error() {
+        // dump_registers in both C tools stops at the first failed
+        // read (unlike the GPIO dump, which continues).
+        let mut calls = Vec::new();
+        let result = dump_all_registers(31, &mut |register| {
+            calls.push(register);
+            if register == 2 {
+                Err(Error::NotFound)
+            } else {
+                Ok(())
+            }
+        });
+        assert!(result.is_err());
+        assert_eq!(calls, [0, 1, 2]);
+
+        let mut count = 0u32;
+        let result = dump_all_registers(255, &mut |_| {
+            count += 1;
+            Ok(())
+        });
+        assert!(result.is_ok());
+        assert_eq!(count, 256);
+    }
+
+    #[test]
+    fn multisynth_params_decode_c_bit_packing() {
+        // dump_multisynth_config in airspy_si5351c.c: an 800/20 MHz
+        // divider (40) encodes as p1 = 128*40 - 512 = 4608, p2 = 0,
+        // p3 = 1, r_div = 0.
+        let params = ms_params(&[0x00, 0x01, 0x00, 0x12, 0x00, 0x00, 0x00, 0x00]);
+        assert_eq!(
+            (params.p1, params.p2, params.p3, params.r_div),
+            (4608, 0, 1, 0)
+        );
+        let mhz = ms_output_mhz(&params);
+        assert!((mhz - 20.0).abs() < 1e-9);
+
+        // Bit packing across fields: p1 spans params[2..5], p2 low
+        // nibble of [5] plus [6..8], p3 high nibble of [5] plus
+        // [0..2], r_div bits 4..7 of [2].
+        let params = ms_params(&[0x00, 0x01, 0x32, 0x03, 0x04, 0x15, 0x06, 0x07]);
+        assert_eq!(params.p1, (0x02 << 16) | (0x03 << 8) | 0x04);
+        assert_eq!(params.p2, (0x05 << 16) | (0x06 << 8) | 0x07);
+        assert_eq!(params.p3, (0x1 << 16) | 0x01);
+        assert_eq!(params.r_div, 3);
+    }
+
+    #[test]
+    fn integer_multisynth_matches_c_float_math() {
+        // MS6/MS7 use float (not double) math in C:
+        // (800.0f / parms) / div_lut[r_div].
+        assert!((ms_int_output_mhz(40, 0) - 20.0).abs() < 1e-6);
+        assert!((ms_int_output_mhz(40, 1) - 10.0).abs() < 1e-6);
+        // div_lut is the power-of-two table {1,2,4,...,128}.
+        assert_eq!(DIV_LUT, [1, 2, 4, 8, 16, 32, 64, 128]);
+    }
+}


### PR DESCRIPTION
## Summary

Ports the clock-generator and tuner register tools (`airspy_si5351c.c`, `airspy_r820t.c`).

**Layout** — the shared engine is `airspy_tools::reg_cli`, unit-tested end to end:
- The order-sensitive `-n`/`-r`/`-w`/`-c` replay of the C getopt loops, parameterized by a per-tool spec capturing the C differences: r820t's `0..=31` register range with C's exact `Error parameter -n/-w` messages vs si5351c's full 8-bit range with **silent** parse failures (C's `parse_int` prints nothing — the loop just breaks into `usage()`).
- The break-on-first-error register dump — the register tools stop at the first failed read, unlike the GPIO tools' visit-everything semantics; both quirks are tested.
- The si5351c **multisynth math**: `p1`/`p2`/`p3`/`r_div` bit unpacking across the 8-register block, the double-precision fractional output formula with C's exact evaluation order (`512*p3` in integer arithmetic first), and the deliberately-**f32** MS6/MS7 integer path — golden-value tested (an 800/20 MHz divider round-trips to exactly 20.0).
- Command-line order recovery from clap indices, sharing the GPIO tools' pattern, plus `gpio_cli::open_from_matches` reuse.

The binaries hold usage text, the C print formats (si5351c's lowercase space-padded `%2x` write echo vs r820t's zero-padded `%02X` — preserved), the multisynth dump wiring, and r820t's 27-byte "default mode for test" register table (`-c`).

## Deviations (upstream bugs fixed per project policy)

1. **`-w` without `-n`**: C writes its default/sentinel register on the wire — register 0 for si5351c, register **255** for r820t (`REGISTER_INVALID` passed straight through). Errors here (tested for both specs).
2. **si5351c truncation**: C's `parse_int` casts `long` to `uint8_t` with no range check, so `-n 300` silently pokes register 44. Out-of-range values reject (silently, matching C's parse-failure style).
3. **Exit status**: failed operations exit 1 (C exits 0).

Kept faithful: the differing C `long_options` tables (si5351c has `--serial`, r820t only `-s` — tested), the partial `MS%d:` line left unterminated when a `-c` read fails mid-block, and register writes staying **ungated** — unlike `airspy_gpiodir`'s `--force`, these are volatile and recoverable by power cycle.

## Testing

13 new unit tests in `reg_cli` (51 tools-lib tests total; 170 workspace-wide). fmt/clippy (`-D warnings`, all features)/doc (`-D warnings`) clean. Smoke-tested both binaries' open-failure, usage, and `--help` paths; live register behavior lands in M6 validation.

Closes #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added command-line tools for reading, writing, dumping, and configuring R820T registers.
  * Added SI5351C register utilities, including multisynth configuration and frequency decoding.
  * Added support for processing multiple register operations in command-line order.
  * Added clear failure reporting with a non-zero exit status when hardware operations fail.
* **Tests**
  * Added coverage for register parsing, operation ordering, error handling, register dumps, and frequency calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->