### PR TITLE
M5: airspy_spiflash (#29)

### DIFF
--- a/crates/airspy-tools/src/bin/airspy_spiflash.rs
+++ b/crates/airspy-tools/src/bin/airspy_spiflash.rs
@@ -1,0 +1,182 @@
+//! Port of `airspy_spiflash.c`: read the SPI flash into a file, or
+//! erase and rewrite it from a file (the firmware-update path).
+//! Output streams and formats track the C tool (status on stdout,
+//! errors on stderr) so the two are diffable.
+
+use std::io::{Read, Write};
+
+use airspy_tools::flash_cli::{
+    FlashRangeError, MAX_LENGTH, flash_command, transfer_chunks, validate_range,
+};
+use airspy_tools::gpio_cli::open_from_matches;
+use libairspy_rs::Device;
+
+/// The C tool's `usage()` (stdout).
+fn usage() {
+    println!("Usage:");
+    println!("\t-a, --address <n>: starting address (default: 0)");
+    println!("\t-l, --length <n>: number of bytes to read (default: 0)");
+    println!("\t-r <filename>: Read data into file (SPIFI@0x80000000).");
+    println!("\t-w <filename>: Write data from file.");
+    println!("\t[-s serial_number_64bits]: Open board with specified 64bits serial number.");
+}
+
+/// Print a range error with C's stderr messages.
+fn print_range_error(error: FlashRangeError, address: u32, length: u64) {
+    match error {
+        FlashRangeError::ZeroLength => eprintln!("Requested transfer of zero bytes."),
+        FlashRangeError::ExceedsFlash => {
+            eprintln!("Request exceeds size of flash memory.");
+            eprintln!("address=0x{address:08X} size={length} Bytes.");
+        }
+    }
+}
+
+/// The read path: chunked `airspy_spiflash_read` into a buffer, then
+/// one file write, exactly as C stages it.
+fn read_flash(device: &Device, path: &str, address: u32, length: u32) -> Result<(), ()> {
+    let Ok(mut file) = std::fs::File::create(path) else {
+        // C: fopen("wb") failure prints to stdout.
+        println!("Error to open file {path}");
+        return Err(());
+    };
+    let mut data = vec![0u8; length as usize];
+    let mut offset = 0usize;
+    for (chunk_address, xfer_len) in transfer_chunks(address, length) {
+        println!("Reading {xfer_len} bytes from 0x{chunk_address:06x}.");
+        let end = offset + usize::from(xfer_len);
+        if let Err(err) = device.spiflash_read(chunk_address, &mut data[offset..end]) {
+            eprintln!(
+                "airspy_spiflash_read() failed: {} ({})",
+                err.name(),
+                err.code()
+            );
+            return Err(());
+        }
+        offset = end;
+    }
+    if file.write_all(&data).is_err() {
+        eprintln!("Failed write to file (wrote 0 bytes).");
+        return Err(());
+    }
+    Ok(())
+}
+
+/// The write path: erase, then chunked `airspy_spiflash_write` from
+/// the already-loaded file contents.
+fn write_flash(device: &Device, address: u32, data: &[u8]) -> Result<(), ()> {
+    // C's message verbatim (the erase clears the whole flash; the
+    // "1st 64KB" wording is the C tool's).
+    println!("Erasing 1st 64KB in SPI flash.");
+    if let Err(err) = device.spiflash_erase() {
+        eprintln!(
+            "airspy_spiflash_erase() failed: {} ({})",
+            err.name(),
+            err.code()
+        );
+        return Err(());
+    }
+    let mut offset = 0usize;
+    #[allow(clippy::cast_possible_truncation)]
+    for (chunk_address, xfer_len) in transfer_chunks(address, data.len() as u32) {
+        println!("Writing {xfer_len} bytes at 0x{chunk_address:06x}.");
+        let end = offset + usize::from(xfer_len);
+        if let Err(err) = device.spiflash_write(chunk_address, &data[offset..end]) {
+            eprintln!(
+                "airspy_spiflash_write() failed: {} ({})",
+                err.name(),
+                err.code()
+            );
+            return Err(());
+        }
+        offset = end;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_lines)]
+fn main() {
+    let matches = flash_command().get_matches();
+    let address = matches.get_one::<u32>("address").copied().unwrap_or(0);
+    let mut length = matches.get_one::<u32>("length").copied().unwrap_or(0);
+    let read_path = matches.get_one::<String>("read");
+    let write_path = matches.get_one::<String>("write");
+
+    // C: `if (write == read)` — both or neither.
+    let path = match (read_path, write_path) {
+        (Some(_), Some(_)) => {
+            eprintln!("Read and write options are mutually exclusive.");
+            usage();
+            std::process::exit(1);
+        }
+        (None, None) => {
+            eprintln!("Specify either read or write option.");
+            usage();
+            std::process::exit(1);
+        }
+        (Some(path), None) | (None, Some(path)) => path.clone(),
+    };
+    let writing = write_path.is_some();
+
+    // Deviation: a flash write erases and rewrites the firmware, so
+    // it requires explicit confirmation (checked before any device
+    // or file access; reads are untouched).
+    if writing && !matches.get_flag("force") {
+        eprintln!(
+            "error: -w erases and rewrites the SPI flash firmware; re-run with --force to confirm"
+        );
+        usage();
+        std::process::exit(1);
+    }
+
+    // For writes C takes the length from the file size.
+    let mut file_data = Vec::new();
+    if writing {
+        let Ok(mut file) = std::fs::File::open(&path) else {
+            // C: fopen("rb") failure prints to stdout.
+            println!("Error to open file {path}");
+            std::process::exit(1);
+        };
+        if file.read_to_end(&mut file_data).is_err() {
+            eprintln!("Failed read file (read 0 bytes).");
+            std::process::exit(1);
+        }
+        println!("File size {} bytes.", file_data.len());
+        // Deviation: C stores ftell into a uint32_t, so a >4 GiB
+        // file wraps past the size check; the real length is checked
+        // before it ever narrows.
+        if file_data.len() > MAX_LENGTH as usize {
+            print_range_error(
+                FlashRangeError::ExceedsFlash,
+                address,
+                file_data.len() as u64,
+            );
+            usage();
+            std::process::exit(1);
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            length = file_data.len() as u32;
+        }
+    }
+
+    if let Err(error) = validate_range(address, length) {
+        print_range_error(error, address, u64::from(length));
+        usage();
+        std::process::exit(1);
+    }
+
+    let Some(device) = open_from_matches(&matches) else {
+        usage();
+        std::process::exit(1);
+    };
+
+    let result = if writing {
+        write_flash(&device, address, &file_data)
+    } else {
+        read_flash(&device, &path, address, length)
+    };
+    if result.is_err() {
+        std::process::exit(1);
+    }
+}

--- a/crates/airspy-tools/src/bin/airspy_spiflash.rs
+++ b/crates/airspy-tools/src/bin/airspy_spiflash.rs
@@ -5,9 +5,8 @@
 
 use std::io::{Read, Write};
 
-use airspy_tools::flash_cli::{
-    FlashRangeError, MAX_LENGTH, flash_command, transfer_chunks, validate_range,
-};
+use airspy_tools::flash_args::flash_command;
+use airspy_tools::flash_cli::{FlashRangeError, MAX_LENGTH, transfer_chunks, validate_range};
 use airspy_tools::gpio_cli::open_from_matches;
 use libairspy_rs::Device;
 

--- a/crates/airspy-tools/src/bin/airspy_spiflash.rs
+++ b/crates/airspy-tools/src/bin/airspy_spiflash.rs
@@ -94,14 +94,11 @@ fn write_flash(device: &Device, address: u32, data: &[u8]) -> Result<(), ()> {
     Ok(())
 }
 
-#[allow(clippy::too_many_lines)]
-fn main() {
-    let matches = flash_command().get_matches();
-    let address = matches.get_one::<u32>("address").copied().unwrap_or(0);
-    let mut length = matches.get_one::<u32>("length").copied().unwrap_or(0);
+/// The `if (write == read)` exclusivity check and `--force` gate:
+/// returns the path and whether this is a write.
+fn resolve_operation(matches: &clap::ArgMatches) -> (String, bool) {
     let read_path = matches.get_one::<String>("read");
     let write_path = matches.get_one::<String>("write");
-
     // C: `if (write == read)` — both or neither.
     let path = match (read_path, write_path) {
         (Some(_), Some(_)) => {
@@ -117,7 +114,6 @@ fn main() {
         (Some(path), None) | (None, Some(path)) => path.clone(),
     };
     let writing = write_path.is_some();
-
     // Deviation: a flash write erases and rewrites the firmware, so
     // it requires explicit confirmation (checked before any device
     // or file access; reads are untouched).
@@ -128,39 +124,63 @@ fn main() {
         usage();
         std::process::exit(1);
     }
+    (path, writing)
+}
 
-    // For writes C takes the length from the file size.
-    let mut file_data = Vec::new();
-    if writing {
-        let Ok(mut file) = std::fs::File::open(&path) else {
-            // C: fopen("rb") failure prints to stdout.
-            println!("Error to open file {path}");
-            std::process::exit(1);
-        };
-        if file.read_to_end(&mut file_data).is_err() {
-            eprintln!("Failed read file (read 0 bytes).");
-            std::process::exit(1);
-        }
-        println!("File size {} bytes.", file_data.len());
-        // Deviation: C stores ftell into a uint32_t, so a >4 GiB
-        // file wraps past the size check; the real length is checked
-        // before it ever narrows.
-        if file_data.len() > MAX_LENGTH as usize {
-            print_range_error(
-                FlashRangeError::ExceedsFlash,
-                address,
-                file_data.len() as u64,
-            );
+/// The write-path file staging, in C's exact order: size first (C's
+/// fseek/ftell — metadata here), the "File size" print, the range
+/// checks, and only then a bounded read of exactly `length` bytes.
+/// Validating before reading also bounds the allocation, so an
+/// unbounded input like /dev/zero is rejected at size 0 as in C.
+fn load_write_file(path: &str, address: u32) -> (Vec<u8>, u32) {
+    let Ok(file) = std::fs::File::open(path) else {
+        // C: fopen("rb") failure prints to stdout.
+        println!("Error to open file {path}");
+        std::process::exit(1);
+    };
+    let file_len = file.metadata().map_or(0, |m| m.len());
+    println!("File size {file_len} bytes.");
+    // Deviation: C stores ftell into a uint32_t, so a >4 GiB file
+    // wraps past the size check; the real length is checked before
+    // it ever narrows.
+    let length = match u32::try_from(file_len) {
+        Ok(length) if length <= MAX_LENGTH => length,
+        _ => {
+            print_range_error(FlashRangeError::ExceedsFlash, address, file_len);
             usage();
             std::process::exit(1);
         }
-        #[allow(clippy::cast_possible_truncation)]
-        {
-            length = file_data.len() as u32;
-        }
-    }
-
+    };
     if let Err(error) = validate_range(address, length) {
+        print_range_error(error, address, u64::from(length));
+        usage();
+        std::process::exit(1);
+    }
+    let mut file_data = Vec::with_capacity(length as usize);
+    let read = file
+        .take(u64::from(length))
+        .read_to_end(&mut file_data)
+        .unwrap_or(0);
+    if read != length as usize {
+        // C: fread short count → "Failed read file (read %d bytes)."
+        eprintln!("Failed read file (read {read} bytes).");
+        std::process::exit(1);
+    }
+    (file_data, length)
+}
+
+fn main() {
+    let matches = flash_command().get_matches();
+    let address = matches.get_one::<u32>("address").copied().unwrap_or(0);
+    let mut length = matches.get_one::<u32>("length").copied().unwrap_or(0);
+    let (path, writing) = resolve_operation(&matches);
+
+    // For writes C takes the length from the file size (validated
+    // inside load_write_file, in C's order).
+    let mut file_data = Vec::new();
+    if writing {
+        (file_data, length) = load_write_file(&path, address);
+    } else if let Err(error) = validate_range(address, length) {
         print_range_error(error, address, u64::from(length));
         usage();
         std::process::exit(1);

--- a/crates/airspy-tools/src/flash_args.rs
+++ b/crates/airspy-tools/src/flash_args.rs
@@ -1,0 +1,76 @@
+//! The `airspy_spiflash` clap command, split from `flash_cli` so
+//! that module keeps its tests at the file bottom.
+//!
+//! NOTE: Codacy's Lizard mis-lexes Rust char literals (`.short('a')`
+//! reads as a lifetime plus a dangling quote), swallowing every
+//! following function into one measurement — this file holds only
+//! the builders so the confusion has nothing meaningful to swallow.
+//! The real fix belongs upstream in Lizard.
+
+/// `parse_u32` for flash addresses and lengths: [`crate::parse_u64`]
+/// semantics with a checked narrowing. Deviation: C's `strtoul`
+/// truncates on LP64, so `-a 0x100000000` became address 0 — with a
+/// forced write, an erase and a firmware write at the wrong address;
+/// out-of-range values reject here.
+fn parse_flash_u32(s: &str) -> Result<u32, crate::ParseU64Error> {
+    u32::try_from(crate::parse_u64(s)?).map_err(|_| crate::ParseU64Error)
+}
+
+/// The `airspy_spiflash` clap command — C's `getopt_long(argc, argv,
+/// "a:l:r:w:s:", long_options, ...)`. The C table's `--reset` entry
+/// is omitted: it has no `case 't'` and no optstring letter, so it
+/// only ever reached C's `opt error` path. `--force` is the
+/// write-confirmation deviation (a `-w` erases and rewrites the
+/// firmware flash).
+pub fn flash_command() -> clap::Command {
+    clap::Command::new("airspy_spiflash")
+        .about("Read and write the Airspy SPI flash")
+        .disable_help_flag(true)
+        .args(range_args())
+        .args(control_args())
+}
+
+/// The `-a`/`-l`/`-r`/`-w` transfer arguments from the C option table.
+/// (Vec rather than an array: the `[T; N]` semicolon in a return
+/// type confuses Lizard's function-boundary parsing.)
+fn range_args() -> Vec<clap::Arg> {
+    vec![
+        clap::Arg::new("address")
+            .short('a')
+            .long("address")
+            .value_name("n")
+            .value_parser(parse_flash_u32)
+            .help("starting address (default: 0)"),
+        clap::Arg::new("length")
+            .short('l')
+            .long("length")
+            .value_name("n")
+            .value_parser(parse_flash_u32)
+            .help("number of bytes to read (default: 0)"),
+        clap::Arg::new("read")
+            .short('r')
+            .long("read")
+            .value_name("filename")
+            .help("Read data into file (SPIFI@0x80000000)"),
+        clap::Arg::new("write")
+            .short('w')
+            .long("write")
+            .value_name("filename")
+            .help("Write data from file"),
+    ]
+}
+
+/// `-s`, `--help`, and the `--force` confirmation deviation.
+fn control_args() -> Vec<clap::Arg> {
+    vec![
+        crate::serial_arg(),
+        clap::Arg::new("help")
+            .long("help")
+            .action(clap::ArgAction::Help)
+            .help("Print help"),
+        clap::Arg::new("force")
+            .long("force")
+            .action(clap::ArgAction::SetTrue)
+            .help("confirm flash writes (-w) — they erase and rewrite the firmware"),
+    ]
+}

--- a/crates/airspy-tools/src/flash_cli.rs
+++ b/crates/airspy-tools/src/flash_cli.rs
@@ -179,11 +179,7 @@ fn range_args() -> Vec<clap::Arg> {
 /// `-s`, `--help`, and the `--force` confirmation deviation.
 fn control_args() -> Vec<clap::Arg> {
     vec![
-        clap::Arg::new("serial")
-            .short('s')
-            .value_name("serial_number_64bits")
-            .value_parser(crate::parse_u64)
-            .help("Open board with specified 64bits serial number"),
+        crate::serial_arg(),
         clap::Arg::new("help")
             .long("help")
             .action(clap::ArgAction::Help)

--- a/crates/airspy-tools/src/flash_cli.rs
+++ b/crates/airspy-tools/src/flash_cli.rs
@@ -65,8 +65,10 @@ pub fn flash_command() -> clap::Command {
 }
 
 /// The `-a`/`-l`/`-r`/`-w` transfer arguments from the C option table.
-fn range_args() -> [clap::Arg; 4] {
-    [
+/// (Vec rather than an array: the `[T; N]` semicolon in a return
+/// type confuses Lizard's function-boundary parsing.)
+fn range_args() -> Vec<clap::Arg> {
+    vec![
         clap::Arg::new("address")
             .short('a')
             .long("address")
@@ -93,8 +95,8 @@ fn range_args() -> [clap::Arg; 4] {
 }
 
 /// `-s`, `--help`, and the `--force` confirmation deviation.
-fn control_args() -> [clap::Arg; 3] {
-    [
+fn control_args() -> Vec<clap::Arg> {
+    vec![
         clap::Arg::new("serial")
             .short('s')
             .value_name("serial_number_64bits")

--- a/crates/airspy-tools/src/flash_cli.rs
+++ b/crates/airspy-tools/src/flash_cli.rs
@@ -50,69 +50,9 @@ pub fn transfer_chunks(address: u32, length: u32) -> impl Iterator<Item = (u32, 
     })
 }
 
-/// The `airspy_spiflash` clap command — C's `getopt_long(argc, argv,
-/// "a:l:r:w:s:", long_options, ...)`. The C table's `--reset` entry
-/// is omitted: it has no `case 't'` and no optstring letter, so it
-/// only ever reached C's `opt error` path. `--force` is the
-/// write-confirmation deviation (a `-w` erases and rewrites the
-/// firmware flash).
-pub fn flash_command() -> clap::Command {
-    clap::Command::new("airspy_spiflash")
-        .about("Read and write the Airspy SPI flash")
-        .disable_help_flag(true)
-        .args(range_args())
-        .args(control_args())
-}
-
-/// The `-a`/`-l`/`-r`/`-w` transfer arguments from the C option table.
-/// (Vec rather than an array: the `[T; N]` semicolon in a return
-/// type confuses Lizard's function-boundary parsing.)
-fn range_args() -> Vec<clap::Arg> {
-    vec![
-        clap::Arg::new("address")
-            .short('a')
-            .long("address")
-            .value_name("n")
-            .value_parser(crate::rx::parse_u32)
-            .help("starting address (default: 0)"),
-        clap::Arg::new("length")
-            .short('l')
-            .long("length")
-            .value_name("n")
-            .value_parser(crate::rx::parse_u32)
-            .help("number of bytes to read (default: 0)"),
-        clap::Arg::new("read")
-            .short('r')
-            .long("read")
-            .value_name("filename")
-            .help("Read data into file (SPIFI@0x80000000)"),
-        clap::Arg::new("write")
-            .short('w')
-            .long("write")
-            .value_name("filename")
-            .help("Write data from file"),
-    ]
-}
-
-/// `-s`, `--help`, and the `--force` confirmation deviation.
-fn control_args() -> Vec<clap::Arg> {
-    vec![
-        clap::Arg::new("serial")
-            .short('s')
-            .value_name("serial_number_64bits")
-            .value_parser(crate::parse_u64)
-            .help("Open board with specified 64bits serial number"),
-        clap::Arg::new("help")
-            .long("help")
-            .action(clap::ArgAction::Help)
-            .help("Print help"),
-        clap::Arg::new("force")
-            .long("force")
-            .action(clap::ArgAction::SetTrue)
-            .help("confirm flash writes (-w) — they erase and rewrite the firmware"),
-    ]
-}
-
+// The clap builders intentionally follow this module — see the
+// Lizard note below.
+#[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -184,4 +124,73 @@ mod tests {
             .expect("parse");
         assert!(matches.get_flag("force"));
     }
+}
+
+// NOTE: the clap builders sit below the test module deliberately.
+// Codacy's Lizard mis-lexes Rust char literals (`.short('a')` reads
+// as a lifetime plus a dangling quote), swallowing every following
+// function into one giant measurement; keeping these last confines
+// the confusion to this tail. Fix belongs upstream in Lizard.
+
+/// The `airspy_spiflash` clap command — C's `getopt_long(argc, argv,
+/// "a:l:r:w:s:", long_options, ...)`. The C table's `--reset` entry
+/// is omitted: it has no `case 't'` and no optstring letter, so it
+/// only ever reached C's `opt error` path. `--force` is the
+/// write-confirmation deviation (a `-w` erases and rewrites the
+/// firmware flash).
+pub fn flash_command() -> clap::Command {
+    clap::Command::new("airspy_spiflash")
+        .about("Read and write the Airspy SPI flash")
+        .disable_help_flag(true)
+        .args(range_args())
+        .args(control_args())
+}
+
+/// The `-a`/`-l`/`-r`/`-w` transfer arguments from the C option table.
+/// (Vec rather than an array: the `[T; N]` semicolon in a return
+/// type confuses Lizard's function-boundary parsing.)
+fn range_args() -> Vec<clap::Arg> {
+    vec![
+        clap::Arg::new("address")
+            .short('a')
+            .long("address")
+            .value_name("n")
+            .value_parser(crate::rx::parse_u32)
+            .help("starting address (default: 0)"),
+        clap::Arg::new("length")
+            .short('l')
+            .long("length")
+            .value_name("n")
+            .value_parser(crate::rx::parse_u32)
+            .help("number of bytes to read (default: 0)"),
+        clap::Arg::new("read")
+            .short('r')
+            .long("read")
+            .value_name("filename")
+            .help("Read data into file (SPIFI@0x80000000)"),
+        clap::Arg::new("write")
+            .short('w')
+            .long("write")
+            .value_name("filename")
+            .help("Write data from file"),
+    ]
+}
+
+/// `-s`, `--help`, and the `--force` confirmation deviation.
+fn control_args() -> Vec<clap::Arg> {
+    vec![
+        clap::Arg::new("serial")
+            .short('s')
+            .value_name("serial_number_64bits")
+            .value_parser(crate::parse_u64)
+            .help("Open board with specified 64bits serial number"),
+        clap::Arg::new("help")
+            .long("help")
+            .action(clap::ArgAction::Help)
+            .help("Print help"),
+        clap::Arg::new("force")
+            .long("force")
+            .action(clap::ArgAction::SetTrue)
+            .help("confirm flash writes (-w) — they erase and rewrite the firmware"),
+    ]
 }

--- a/crates/airspy-tools/src/flash_cli.rs
+++ b/crates/airspy-tools/src/flash_cli.rs
@@ -1,0 +1,185 @@
+//! Shared logic for the `airspy_spiflash` binary, ported from
+//! `airspy-tools/src/airspy_spiflash.c`: the flash-size bound, the
+//! 256-byte transfer chunking, and the range validation. The binary
+//! holds the C print formats and the device/file wiring.
+
+/// `MAX_LENGTH` in `airspy_spiflash.c` — "8 Mbit flash" (1 MiB).
+pub const MAX_LENGTH: u32 = 0x0010_0000;
+
+/// The 256-byte transfer size in the C read/write loops
+/// (`xfer_len = (tmp_length > 256) ? 256 : tmp_length`).
+const XFER_CHUNK: u32 = 256;
+
+/// Why a requested range is invalid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlashRangeError {
+    /// C's "Requested transfer of zero bytes." check.
+    ZeroLength,
+    /// C's "Request exceeds size of flash memory." check — with the
+    /// address included (deviation: C tests only `length >
+    /// MAX_LENGTH`, so an offset transfer could erase and then fail
+    /// partway through the writes).
+    ExceedsFlash,
+}
+
+/// The pre-transfer validation from C `main()`, address-inclusive.
+pub fn validate_range(address: u32, length: u32) -> Result<(), FlashRangeError> {
+    if length == 0 {
+        return Err(FlashRangeError::ZeroLength);
+    }
+    if u64::from(address) + u64::from(length) > u64::from(MAX_LENGTH) {
+        return Err(FlashRangeError::ExceedsFlash);
+    }
+    Ok(())
+}
+
+/// The C read/write loop shape: `(address, xfer_len)` pairs walking
+/// the range in 256-byte (`XFER_CHUNK`) transfers.
+pub fn transfer_chunks(address: u32, length: u32) -> impl Iterator<Item = (u32, u16)> {
+    let mut address = address;
+    let mut remaining = length;
+    std::iter::from_fn(move || {
+        if remaining == 0 {
+            return None;
+        }
+        let xfer = remaining.min(XFER_CHUNK);
+        let chunk = (address, u16::try_from(xfer).unwrap_or(u16::MAX));
+        address += xfer;
+        remaining -= xfer;
+        Some(chunk)
+    })
+}
+
+/// The `airspy_spiflash` clap command — C's `getopt_long(argc, argv,
+/// "a:l:r:w:s:", long_options, ...)`. The C table's `--reset` entry
+/// is omitted: it has no `case 't'` and no optstring letter, so it
+/// only ever reached C's `opt error` path. `--force` is the
+/// write-confirmation deviation (a `-w` erases and rewrites the
+/// firmware flash).
+pub fn flash_command() -> clap::Command {
+    clap::Command::new("airspy_spiflash")
+        .about("Read and write the Airspy SPI flash")
+        .disable_help_flag(true)
+        .arg(
+            clap::Arg::new("help")
+                .long("help")
+                .action(clap::ArgAction::Help)
+                .help("Print help"),
+        )
+        .arg(
+            clap::Arg::new("address")
+                .short('a')
+                .long("address")
+                .value_name("n")
+                .value_parser(crate::rx::parse_u32)
+                .help("starting address (default: 0)"),
+        )
+        .arg(
+            clap::Arg::new("length")
+                .short('l')
+                .long("length")
+                .value_name("n")
+                .value_parser(crate::rx::parse_u32)
+                .help("number of bytes to read (default: 0)"),
+        )
+        .arg(
+            clap::Arg::new("read")
+                .short('r')
+                .long("read")
+                .value_name("filename")
+                .help("Read data into file (SPIFI@0x80000000)"),
+        )
+        .arg(
+            clap::Arg::new("write")
+                .short('w')
+                .long("write")
+                .value_name("filename")
+                .help("Write data from file"),
+        )
+        .arg(
+            clap::Arg::new("serial")
+                .short('s')
+                .value_name("serial_number_64bits")
+                .value_parser(crate::parse_u64)
+                .help("Open board with specified 64bits serial number"),
+        )
+        .arg(
+            clap::Arg::new("force")
+                .long("force")
+                .action(clap::ArgAction::SetTrue)
+                .help("confirm flash writes (-w) — they erase and rewrite the firmware"),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_length_matches_c_define() {
+        // "8 Mbit flash" — MAX_LENGTH 0x100000 in airspy_spiflash.c.
+        assert_eq!(MAX_LENGTH, 0x0010_0000);
+    }
+
+    #[test]
+    fn chunks_walk_the_range_in_256_byte_transfers() {
+        // The C read/write loops: xfer_len = min(remaining, 256),
+        // advancing address and remaining together.
+        let chunks: Vec<(u32, u16)> = transfer_chunks(0x100, 600).collect();
+        assert_eq!(chunks, [(0x100, 256), (0x200, 256), (0x300, 88)]);
+        let chunks: Vec<(u32, u16)> = transfer_chunks(0, 256).collect();
+        assert_eq!(chunks, [(0, 256)]);
+        assert_eq!(transfer_chunks(5, 0).count(), 0);
+    }
+
+    #[test]
+    fn range_validation_covers_c_checks_and_the_address_fix() {
+        // C checks length == 0 and length > MAX_LENGTH; deviation:
+        // the flash-size check includes the address, so a transfer
+        // cannot run off the end of the flash mid-operation (C would
+        // erase, then fail partway through the writes).
+        assert_eq!(validate_range(0, 0), Err(FlashRangeError::ZeroLength));
+        assert_eq!(validate_range(0, MAX_LENGTH), Ok(()));
+        assert_eq!(
+            validate_range(1, MAX_LENGTH),
+            Err(FlashRangeError::ExceedsFlash)
+        );
+        assert_eq!(
+            validate_range(0x000F_0000, 0x0002_0000),
+            Err(FlashRangeError::ExceedsFlash)
+        );
+        assert_eq!(validate_range(0x000F_0000, 0x0001_0000), Ok(()));
+        // u32 overflow cannot sneak past the check.
+        assert_eq!(
+            validate_range(u32::MAX, u32::MAX),
+            Err(FlashRangeError::ExceedsFlash)
+        );
+    }
+
+    #[test]
+    fn command_mirrors_c_getopt_flags() {
+        // getopt_long "a:l:r:w:s:" — the C long_options table also
+        // lists { "reset", 't' }, but the option string and switch
+        // have no 't', so --reset only ever hits C's error path;
+        // deviation: it is omitted here.
+        let matches = flash_command()
+            .try_get_matches_from(["t", "-a", "0x1000", "-l", "256", "-r", "dump.bin"])
+            .expect("parse");
+        assert_eq!(matches.get_one::<u32>("address"), Some(&0x1000));
+        assert_eq!(matches.get_one::<u32>("length"), Some(&256));
+        assert_eq!(
+            matches.get_one::<String>("read").map(String::as_str),
+            Some("dump.bin")
+        );
+        assert!(
+            flash_command()
+                .try_get_matches_from(["t", "--reset"])
+                .is_err()
+        );
+        // --force is the write-confirmation deviation.
+        let matches = flash_command()
+            .try_get_matches_from(["t", "-w", "fw.bin", "--force"])
+            .expect("parse");
+        assert!(matches.get_flag("force"));
+    }
+}

--- a/crates/airspy-tools/src/flash_cli.rs
+++ b/crates/airspy-tools/src/flash_cli.rs
@@ -60,55 +60,55 @@ pub fn flash_command() -> clap::Command {
     clap::Command::new("airspy_spiflash")
         .about("Read and write the Airspy SPI flash")
         .disable_help_flag(true)
-        .arg(
-            clap::Arg::new("help")
-                .long("help")
-                .action(clap::ArgAction::Help)
-                .help("Print help"),
-        )
-        .arg(
-            clap::Arg::new("address")
-                .short('a')
-                .long("address")
-                .value_name("n")
-                .value_parser(crate::rx::parse_u32)
-                .help("starting address (default: 0)"),
-        )
-        .arg(
-            clap::Arg::new("length")
-                .short('l')
-                .long("length")
-                .value_name("n")
-                .value_parser(crate::rx::parse_u32)
-                .help("number of bytes to read (default: 0)"),
-        )
-        .arg(
-            clap::Arg::new("read")
-                .short('r')
-                .long("read")
-                .value_name("filename")
-                .help("Read data into file (SPIFI@0x80000000)"),
-        )
-        .arg(
-            clap::Arg::new("write")
-                .short('w')
-                .long("write")
-                .value_name("filename")
-                .help("Write data from file"),
-        )
-        .arg(
-            clap::Arg::new("serial")
-                .short('s')
-                .value_name("serial_number_64bits")
-                .value_parser(crate::parse_u64)
-                .help("Open board with specified 64bits serial number"),
-        )
-        .arg(
-            clap::Arg::new("force")
-                .long("force")
-                .action(clap::ArgAction::SetTrue)
-                .help("confirm flash writes (-w) — they erase and rewrite the firmware"),
-        )
+        .args(range_args())
+        .args(control_args())
+}
+
+/// The `-a`/`-l`/`-r`/`-w` transfer arguments from the C option table.
+fn range_args() -> [clap::Arg; 4] {
+    [
+        clap::Arg::new("address")
+            .short('a')
+            .long("address")
+            .value_name("n")
+            .value_parser(crate::rx::parse_u32)
+            .help("starting address (default: 0)"),
+        clap::Arg::new("length")
+            .short('l')
+            .long("length")
+            .value_name("n")
+            .value_parser(crate::rx::parse_u32)
+            .help("number of bytes to read (default: 0)"),
+        clap::Arg::new("read")
+            .short('r')
+            .long("read")
+            .value_name("filename")
+            .help("Read data into file (SPIFI@0x80000000)"),
+        clap::Arg::new("write")
+            .short('w')
+            .long("write")
+            .value_name("filename")
+            .help("Write data from file"),
+    ]
+}
+
+/// `-s`, `--help`, and the `--force` confirmation deviation.
+fn control_args() -> [clap::Arg; 3] {
+    [
+        clap::Arg::new("serial")
+            .short('s')
+            .value_name("serial_number_64bits")
+            .value_parser(crate::parse_u64)
+            .help("Open board with specified 64bits serial number"),
+        clap::Arg::new("help")
+            .long("help")
+            .action(clap::ArgAction::Help)
+            .help("Print help"),
+        clap::Arg::new("force")
+            .long("force")
+            .action(clap::ArgAction::SetTrue)
+            .help("confirm flash writes (-w) — they erase and rewrite the firmware"),
+    ]
 }
 
 #[cfg(test)]

--- a/crates/airspy-tools/src/flash_cli.rs
+++ b/crates/airspy-tools/src/flash_cli.rs
@@ -6,8 +6,9 @@
 /// `MAX_LENGTH` in `airspy_spiflash.c` — "8 Mbit flash" (1 MiB).
 pub const MAX_LENGTH: u32 = 0x0010_0000;
 
-/// The 256-byte transfer size in the C read/write loops
-/// (`xfer_len = (tmp_length > 256) ? 256 : tmp_length`).
+/// The 256-byte transfer size in the read and write loops of C
+/// `main()` (`xfer_len = (tmp_length > 256) ? 256 : tmp_length` in
+/// `airspy_spiflash.c`).
 const XFER_CHUNK: u32 = 256;
 
 /// Why a requested range is invalid.

--- a/crates/airspy-tools/src/flash_cli.rs
+++ b/crates/airspy-tools/src/flash_cli.rs
@@ -50,12 +50,10 @@ pub fn transfer_chunks(address: u32, length: u32) -> impl Iterator<Item = (u32, 
     })
 }
 
-// The clap builders intentionally follow this module — see the
-// Lizard note below.
-#[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::flash_args::flash_command;
 
     #[test]
     fn max_length_matches_c_define() {
@@ -118,75 +116,17 @@ mod tests {
                 .try_get_matches_from(["t", "--reset"])
                 .is_err()
         );
+        // Deviation: values past u32 reject instead of C's strtoul
+        // truncation (-a 0x100000000 became address 0 in C).
+        assert!(
+            flash_command()
+                .try_get_matches_from(["t", "-a", "0x100000000", "-r", "f"])
+                .is_err()
+        );
         // --force is the write-confirmation deviation.
         let matches = flash_command()
             .try_get_matches_from(["t", "-w", "fw.bin", "--force"])
             .expect("parse");
         assert!(matches.get_flag("force"));
     }
-}
-
-// NOTE: the clap builders sit below the test module deliberately.
-// Codacy's Lizard mis-lexes Rust char literals (`.short('a')` reads
-// as a lifetime plus a dangling quote), swallowing every following
-// function into one giant measurement; keeping these last confines
-// the confusion to this tail. Fix belongs upstream in Lizard.
-
-/// The `airspy_spiflash` clap command — C's `getopt_long(argc, argv,
-/// "a:l:r:w:s:", long_options, ...)`. The C table's `--reset` entry
-/// is omitted: it has no `case 't'` and no optstring letter, so it
-/// only ever reached C's `opt error` path. `--force` is the
-/// write-confirmation deviation (a `-w` erases and rewrites the
-/// firmware flash).
-pub fn flash_command() -> clap::Command {
-    clap::Command::new("airspy_spiflash")
-        .about("Read and write the Airspy SPI flash")
-        .disable_help_flag(true)
-        .args(range_args())
-        .args(control_args())
-}
-
-/// The `-a`/`-l`/`-r`/`-w` transfer arguments from the C option table.
-/// (Vec rather than an array: the `[T; N]` semicolon in a return
-/// type confuses Lizard's function-boundary parsing.)
-fn range_args() -> Vec<clap::Arg> {
-    vec![
-        clap::Arg::new("address")
-            .short('a')
-            .long("address")
-            .value_name("n")
-            .value_parser(crate::rx::parse_u32)
-            .help("starting address (default: 0)"),
-        clap::Arg::new("length")
-            .short('l')
-            .long("length")
-            .value_name("n")
-            .value_parser(crate::rx::parse_u32)
-            .help("number of bytes to read (default: 0)"),
-        clap::Arg::new("read")
-            .short('r')
-            .long("read")
-            .value_name("filename")
-            .help("Read data into file (SPIFI@0x80000000)"),
-        clap::Arg::new("write")
-            .short('w')
-            .long("write")
-            .value_name("filename")
-            .help("Write data from file"),
-    ]
-}
-
-/// `-s`, `--help`, and the `--force` confirmation deviation.
-fn control_args() -> Vec<clap::Arg> {
-    vec![
-        crate::serial_arg(),
-        clap::Arg::new("help")
-            .long("help")
-            .action(clap::ArgAction::Help)
-            .help("Print help"),
-        clap::Arg::new("force")
-            .long("force")
-            .action(clap::ArgAction::SetTrue)
-            .help("confirm flash writes (-w) — they erase and rewrite the firmware"),
-    ]
 }

--- a/crates/airspy-tools/src/gpio_cli.rs
+++ b/crates/airspy-tools/src/gpio_cli.rs
@@ -338,13 +338,7 @@ pub fn gpio_command(name: &'static str, about: &'static str) -> clap::Command {
                 .action(clap::ArgAction::Append)
                 .help("write the selection set by the last -p/-n with value<v>[0,1]"),
         )
-        .arg(
-            clap::Arg::new("serial")
-                .short('s')
-                .value_name("serial_number_64bits")
-                .value_parser(crate::parse_u64)
-                .help("Open board with specified 64bits serial number"),
-        )
+        .arg(crate::serial_arg())
 }
 
 /// Recover the C getopt loop's op sequence: each occurrence of

--- a/crates/airspy-tools/src/lib.rs
+++ b/crates/airspy-tools/src/lib.rs
@@ -5,6 +5,7 @@
 //! holds the argument-parsing and output-formatting code they share.
 #![warn(missing_docs)]
 
+pub mod flash_cli;
 pub mod gpio_cli;
 pub mod reg_cli;
 pub mod rx;

--- a/crates/airspy-tools/src/lib.rs
+++ b/crates/airspy-tools/src/lib.rs
@@ -105,6 +105,17 @@ fn strtoull_whole(s: &str, base: u32) -> Option<u64> {
     })
 }
 
+/// The shared `-s serial_number_64bits` argument every tool's C
+/// getopt table carries; callers needing a long form (only
+/// `airspy_si5351c.c` lists `--serial`) add it.
+pub fn serial_arg() -> clap::Arg {
+    clap::Arg::new("serial")
+        .short('s')
+        .value_name("serial_number_64bits")
+        .value_parser(parse_u64)
+        .help("Open board with specified 64bits serial number")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/airspy-tools/src/lib.rs
+++ b/crates/airspy-tools/src/lib.rs
@@ -5,6 +5,7 @@
 //! holds the argument-parsing and output-formatting code they share.
 #![warn(missing_docs)]
 
+pub mod flash_args;
 pub mod flash_cli;
 pub mod gpio_cli;
 pub mod reg_cli;

--- a/crates/airspy-tools/src/reg_cli.rs
+++ b/crates/airspy-tools/src/reg_cli.rs
@@ -235,11 +235,7 @@ pub fn ms_int_output_mhz(parms: u8, r_div: u32) -> f32 {
 /// `serial_long` mirrors the C difference: `airspy_si5351c.c` lists
 /// a `--serial` long option, `airspy_r820t.c` has only `-s`.
 pub fn reg_command(name: &'static str, about: &'static str, serial_long: bool) -> clap::Command {
-    let mut serial = clap::Arg::new("serial")
-        .short('s')
-        .value_name("serial_number_64bits")
-        .value_parser(crate::parse_u64)
-        .help("Open board with specified 64bits serial number");
+    let mut serial = crate::serial_arg();
     if serial_long {
         serial = serial.long("serial");
     }


### PR DESCRIPTION
## Summary

Ports `airspy_spiflash.c` — read the SPI flash into a file, or erase and rewrite it from a file (the firmware-update path).

**Layout** — `airspy_tools::flash_cli` holds the unit-tested logic: the 1 MiB `MAX_LENGTH` bound, the 256-byte transfer chunking shared by C's read and write loops (tested walking a range with a short tail), address-inclusive range validation, and the clap command mirroring the C getopt flags. The binary keeps C's exact stream split — status (`Reading %d bytes from 0x%06x.`, `File size %d bytes.`, `Erasing 1st 64KB in SPI flash.` verbatim) on stdout, errors on stderr — and stages reads into one buffer before a single file write, exactly as C does.

## Deviations (per project policy; the issue pre-approves confirmation guardrails)

1. **`-w` requires `--force`** — this is the tool the destructive-ops rule was written for: the write path erases the firmware flash before rewriting it. Gate fires before any device or file access; reads are untouched. (Same pattern as `airspy_gpiodir` in #64.)
2. **Address-inclusive size check**: C validates only `length > MAX_LENGTH`, so `-a 0xF0000` with a 128 KiB file passes, erases the flash, then fails partway through the writes. The check here includes the address (tested, including the u32-overflow corner).
3. **Real-size rejection**: C stores `ftell` into a `uint32_t`, so a >4 GiB file wraps past the size check; the real length is validated before narrowing.
4. **`--reset` omitted**: C's `long_options` lists `{ "reset", 't' }` but the optstring and switch have no `t`, so `--reset` only ever reached C's `opt error` path — a dead entry, documented and tested as rejected.

## Testing

4 new unit tests in `flash_cli` (56 tools-lib tests; 175 workspace-wide). fmt/clippy (`-D warnings`, all features)/doc (`-D warnings`) clean. Smoke-tested the force gate, mutual-exclusion, zero-length, exceeds-flash, and open-failure paths without hardware; live flash behavior lands in M6 validation (carefully).

Closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an SPI flash utility for reading contents to a file.
  * Added support for erasing and rewriting flash from a file.
  * Added device selection by serial number and configurable address and length ranges.
  * Added chunked transfers for reliable flash operations.
  * Added safeguards requiring explicit confirmation before writes.
  * Added command-line help and validation for ranges, file sizes, and transfer options.
  * Added clear handling for transfer, usage, and unsupported reset-option errors.
  * Standardized serial-number options across device tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->