### PR TITLE
M5: airspy_calibrate (#30)

### DIFF
--- a/crates/airspy-tools/src/bin/airspy_calibrate.rs
+++ b/crates/airspy-tools/src/bin/airspy_calibrate.rs
@@ -4,7 +4,9 @@
 //! diffable.
 
 use airspy_tools::calib_args::calib_command;
-use airspy_tools::calib_cli::{CALIB_HEADER, CALIB_LEN, CALIB_OFFSET, Calib, format_calib_time};
+use airspy_tools::calib_cli::{
+    CALIB_HEADER, CALIB_LEN, CALIB_OFFSET, CALIB_SECTOR, Calib, format_calib_time,
+};
 use libairspy_rs::Device;
 
 /// The C tool's `usage()` (stdout).
@@ -55,7 +57,7 @@ fn read_calibration(device: &Device) -> Result<(), ()> {
 /// printing what will be written first, as C does.
 fn write_calibration(device: &Device, correction_ppb: i32) -> Result<(), ()> {
     println!("Erasing sector 2 (calibration) in SPI flash.");
-    if let Err(_err) = device.spiflash_erase_sector(2) {
+    if let Err(_err) = device.spiflash_erase_sector(CALIB_SECTOR) {
         eprintln!("Failed to erase sector 2.");
         return Err(());
     }

--- a/crates/airspy-tools/src/bin/airspy_calibrate.rs
+++ b/crates/airspy-tools/src/bin/airspy_calibrate.rs
@@ -1,0 +1,127 @@
+//! Port of `airspy_calibrate.c`: read or write the calibration
+//! record stored in the SPI flash (offset 0x20000, sector 2).
+//! Output streams and formats track the C tool so the two are
+//! diffable.
+
+use airspy_tools::calib_args::calib_command;
+use airspy_tools::calib_cli::{CALIB_HEADER, CALIB_LEN, CALIB_OFFSET, Calib, format_calib_time};
+use libairspy_rs::Device;
+
+/// The C tool's `usage()` (stdout).
+fn usage() {
+    println!("Usage:");
+    println!("\t-r: Read and display calibration data.");
+    println!("\t-w <calibration in ppb>: Erase and Write calibration in ppb.");
+}
+
+/// The shared timestamp + ppb print of the C read and write paths.
+fn print_calib(calib: &Calib) {
+    let local = chrono::DateTime::from_timestamp(i64::from(calib.timestamp), 0)
+        .unwrap_or_default()
+        .with_timezone(&chrono::Local);
+    println!(
+        "Calibration timestamp: {}\nCalibration correction in ppb: {}",
+        format_calib_time(&local),
+        calib.correction_ppb
+    );
+}
+
+/// The `-r` path: one 12-byte flash read, then the display.
+fn read_calibration(device: &Device) -> Result<(), ()> {
+    println!("Reading {CALIB_LEN} bytes from 0x{CALIB_OFFSET:06x}.");
+    let mut raw = [0u8; CALIB_LEN];
+    if let Err(err) = device.spiflash_read(CALIB_OFFSET, &mut raw) {
+        eprintln!(
+            "airspy_spiflash_read() failed: {} ({})",
+            err.name(),
+            err.code()
+        );
+        return Err(());
+    }
+    let calib = Calib::from_le_bytes(&raw);
+    // Deviation: C prints whatever it read; warn when the magic is
+    // missing (erased flash reads as all 0xFF) but display as C does.
+    if !calib.header_valid() {
+        eprintln!(
+            "warning: calibration header 0x{:08X} does not match 0x{CALIB_HEADER:08X}; the record may be unprogrammed",
+            calib.header
+        );
+    }
+    print_calib(&calib);
+    Ok(())
+}
+
+/// The `-w` path: erase sector 2, then write the fresh record —
+/// printing what will be written first, as C does.
+fn write_calibration(device: &Device, correction_ppb: i32) -> Result<(), ()> {
+    println!("Erasing sector 2 (calibration) in SPI flash.");
+    if let Err(_err) = device.spiflash_erase_sector(2) {
+        eprintln!("Failed to erase sector 2.");
+        return Err(());
+    }
+
+    // C: calib.timestamp = (uint32_t)time(NULL).
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let calib = Calib {
+        header: CALIB_HEADER,
+        timestamp: chrono::Utc::now().timestamp() as u32,
+        correction_ppb,
+    };
+    println!("Writing calibration {CALIB_LEN} bytes at 0x{CALIB_OFFSET:06x}.");
+    print_calib(&calib);
+    if let Err(_err) = device.spiflash_write(CALIB_OFFSET, &calib.to_le_bytes()) {
+        eprintln!("Failed to write calibration data.");
+        return Err(());
+    }
+    Ok(())
+}
+
+fn main() {
+    let matches = calib_command().get_matches();
+    let read = matches.get_flag("read");
+    let write = matches.get_one::<i32>("write").copied();
+
+    // C: `if (write == read)` — both or neither.
+    match (read, write) {
+        (true, Some(_)) => {
+            eprintln!("Read and write options are mutually exclusive.");
+            usage();
+            std::process::exit(1);
+        }
+        (false, None) => {
+            eprintln!("Specify either read or write option.");
+            usage();
+            std::process::exit(1);
+        }
+        _ => {}
+    }
+
+    // Deviation: a calibration write erases sector 2 and rewrites
+    // the record, so it requires explicit confirmation (checked
+    // before the device opens; reads are untouched).
+    if write.is_some() && !matches.get_flag("force") {
+        eprintln!(
+            "error: -w erases the calibration sector and rewrites it; re-run with --force to confirm"
+        );
+        usage();
+        std::process::exit(1);
+    }
+
+    // C: this tool opens without a serial option and prints its own
+    // failure message.
+    let device = match Device::open() {
+        Ok(device) => device,
+        Err(_err) => {
+            eprintln!("Failed to open airspy device.");
+            std::process::exit(1);
+        }
+    };
+
+    let result = match write {
+        Some(correction_ppb) => write_calibration(&device, correction_ppb),
+        None => read_calibration(&device),
+    };
+    if result.is_err() {
+        std::process::exit(1);
+    }
+}

--- a/crates/airspy-tools/src/calib_args.rs
+++ b/crates/airspy-tools/src/calib_args.rs
@@ -1,0 +1,41 @@
+//! The `airspy_calibrate` clap command, in its own module so
+//! Codacy's Lizard (which mis-lexes Rust char literals such as
+//! `.short('r')`) has nothing meaningful to swallow after it.
+
+/// The `airspy_calibrate` clap command — C's `getopt(argc, argv,
+/// "rw:")`. This is the only tool without a serial option; kept
+/// faithful. `--force` is the calibration-write confirmation
+/// deviation, and `-w` parses strictly (deviation: C's `atoi`
+/// silently turned garbage into 0 before writing it to flash).
+pub fn calib_command() -> clap::Command {
+    clap::Command::new("airspy_calibrate")
+        .about("Read or write the Airspy calibration record")
+        .disable_help_flag(true)
+        .arg(
+            clap::Arg::new("help")
+                .long("help")
+                .action(clap::ArgAction::Help)
+                .help("Print help"),
+        )
+        .arg(
+            clap::Arg::new("read")
+                .short('r')
+                .action(clap::ArgAction::SetTrue)
+                .help("Read and display calibration data"),
+        )
+        .arg(
+            clap::Arg::new("write")
+                .short('w')
+                .value_name("calibration in ppb")
+                // getopt takes a negative optarg (-w -1500) natively.
+                .allow_negative_numbers(true)
+                .value_parser(clap::value_parser!(i32))
+                .help("Erase and Write calibration in ppb"),
+        )
+        .arg(
+            clap::Arg::new("force")
+                .long("force")
+                .action(clap::ArgAction::SetTrue)
+                .help("confirm calibration writes (-w) — they erase the calibration sector"),
+        )
+}

--- a/crates/airspy-tools/src/calib_cli.rs
+++ b/crates/airspy-tools/src/calib_cli.rs
@@ -1,0 +1,163 @@
+//! Shared logic for the `airspy_calibrate` binary, ported from
+//! `airspy-tools/src/airspy_calibrate.c`: the flash calibration
+//! record layout, its (de)serialization, and the timestamp
+//! formatting. The binary holds the C print formats and the
+//! device wiring.
+
+use chrono::{Datelike, Timelike};
+
+/// `AIRSPY_FLASH_CALIB_OFFSET` in `airspy_calibrate.c` — "After
+/// 128KB (Reserved for Firmware + 64KB Spare)".
+pub const CALIB_OFFSET: u32 = 0x20000;
+/// `AIRSPY_FLASH_CALIB_HEADER` in `airspy_calibrate.c`.
+pub const CALIB_HEADER: u32 = 0xCA1B_0001;
+/// `sizeof(airspy_calib_t)` — three packed 32-bit fields.
+pub const CALIB_LEN: usize = 12;
+
+/// `airspy_calib_t` in `airspy_calibrate.c`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Calib {
+    /// Shall equal [`CALIB_HEADER`].
+    pub header: u32,
+    /// Epoch Unix timestamp.
+    pub timestamp: u32,
+    /// The frequency correction in parts per billion.
+    pub correction_ppb: i32,
+}
+
+impl Calib {
+    /// Decode the 12 flash bytes (C reads the packed struct's raw
+    /// memory; little-endian on every supported target).
+    pub fn from_le_bytes(raw: &[u8; CALIB_LEN]) -> Self {
+        let word = |i: usize| {
+            let mut bytes = [0u8; 4];
+            bytes.copy_from_slice(&raw[i..i + 4]);
+            bytes
+        };
+        Self {
+            header: u32::from_le_bytes(word(0)),
+            timestamp: u32::from_le_bytes(word(4)),
+            correction_ppb: i32::from_le_bytes(word(8)),
+        }
+    }
+
+    /// Encode the 12 flash bytes.
+    pub fn to_le_bytes(&self) -> [u8; CALIB_LEN] {
+        let mut raw = [0u8; CALIB_LEN];
+        raw[0..4].copy_from_slice(&self.header.to_le_bytes());
+        raw[4..8].copy_from_slice(&self.timestamp.to_le_bytes());
+        raw[8..12].copy_from_slice(&self.correction_ppb.to_le_bytes());
+        raw
+    }
+
+    /// Whether the magic matches. Deviation: C displays whatever it
+    /// read; the binary warns when this is false (erased flash reads
+    /// as all 0xFF).
+    pub fn header_valid(&self) -> bool {
+        self.header == CALIB_HEADER
+    }
+}
+
+/// The `%04d/%02d/%02d %02d:%02d:%02d` timestamp format shared by
+/// the read and write paths of `airspy_calibrate.c` (fed from
+/// `localtime`).
+pub fn format_calib_time(dt: &(impl Datelike + Timelike)) -> String {
+    format!(
+        "{:04}/{:02}/{:02} {:02}:{:02}:{:02}",
+        dt.year(),
+        dt.month(),
+        dt.day(),
+        dt.hour(),
+        dt.minute(),
+        dt.second()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::calib_args::calib_command;
+
+    #[test]
+    fn constants_match_c_defines() {
+        // airspy_calibrate.c: "After 128KB (Reserved for Firmware +
+        // 64KB Spare)" and the CA1B magic.
+        assert_eq!(CALIB_OFFSET, 0x20000);
+        assert_eq!(CALIB_HEADER, 0xCA1B_0001);
+        assert_eq!(CALIB_LEN, 12);
+    }
+
+    #[test]
+    fn calib_round_trips_little_endian() {
+        // airspy_calib_t: uint32 header, uint32 timestamp, int32
+        // correction_ppb — 12 packed bytes, little-endian on the
+        // wire and in flash.
+        let calib = Calib {
+            header: CALIB_HEADER,
+            timestamp: 1_766_620_800,
+            correction_ppb: -1500,
+        };
+        let bytes = calib.to_le_bytes();
+        assert_eq!(bytes.len(), CALIB_LEN);
+        assert_eq!(bytes[0..4], CALIB_HEADER.to_le_bytes());
+        assert_eq!(Calib::from_le_bytes(&bytes), calib);
+    }
+
+    #[test]
+    fn header_validity_flags_unprogrammed_flash() {
+        // Deviation: C displays whatever it read (erased flash is all
+        // 0xFF, so garbage timestamps print); the port warns when the
+        // magic does not match.
+        let good = Calib {
+            header: CALIB_HEADER,
+            timestamp: 0,
+            correction_ppb: 0,
+        };
+        assert!(good.header_valid());
+        let erased = Calib::from_le_bytes(&[0xFF; CALIB_LEN]);
+        assert!(!erased.header_valid());
+    }
+
+    #[test]
+    fn timestamp_formats_like_c_localtime_printf() {
+        // The %04d/%02d/%02d %02d:%02d:%02d format in
+        // airspy_calibrate.c (both the read and write paths).
+        let dt = chrono::NaiveDate::from_ymd_opt(2026, 8, 25)
+            .expect("date")
+            .and_hms_opt(7, 5, 9)
+            .expect("time");
+        assert_eq!(format_calib_time(&dt), "2026/08/25 07:05:09");
+    }
+
+    #[test]
+    fn command_mirrors_c_getopt_flags() {
+        // getopt(argc, argv, "rw:") — no serial option in this tool;
+        // --force is the calibration-write confirmation deviation.
+        let matches = calib_command()
+            .try_get_matches_from(["t", "-r"])
+            .expect("parse");
+        assert!(matches.get_flag("read"));
+        let matches = calib_command()
+            .try_get_matches_from(["t", "-w", "-1500", "--force"])
+            .expect("parse");
+        assert_eq!(matches.get_one::<i32>("write"), Some(&-1500));
+        assert!(matches.get_flag("force"));
+        assert!(
+            calib_command()
+                .try_get_matches_from(["t", "-s", "0x1"])
+                .is_err()
+        );
+        // Deviation: C's atoi silently turns garbage into 0 (and
+        // "12abc" into 12); a value bound for flash parses strictly.
+        assert!(
+            calib_command()
+                .try_get_matches_from(["t", "-w", "abc"])
+                .is_err()
+        );
+        assert!(
+            calib_command()
+                .try_get_matches_from(["t", "-w", "12abc"])
+                .is_err()
+        );
+    }
+}

--- a/crates/airspy-tools/src/calib_cli.rs
+++ b/crates/airspy-tools/src/calib_cli.rs
@@ -13,6 +13,10 @@ pub const CALIB_OFFSET: u32 = 0x20000;
 pub const CALIB_HEADER: u32 = 0xCA1B_0001;
 /// `sizeof(airspy_calib_t)` — three packed 32-bit fields.
 pub const CALIB_LEN: usize = 12;
+/// The calibration sector — the literal `2` in
+/// `airspy_spiflash_erase_sector(device, 2)` and the "Erasing
+/// sector 2 (calibration)" message (`airspy_calibrate.c`).
+pub const CALIB_SECTOR: u16 = 2;
 
 /// `airspy_calib_t` in `airspy_calibrate.c`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -85,6 +89,7 @@ mod tests {
         assert_eq!(CALIB_OFFSET, 0x20000);
         assert_eq!(CALIB_HEADER, 0xCA1B_0001);
         assert_eq!(CALIB_LEN, 12);
+        assert_eq!(CALIB_SECTOR, 2);
     }
 
     #[test]

--- a/crates/airspy-tools/src/lib.rs
+++ b/crates/airspy-tools/src/lib.rs
@@ -5,6 +5,8 @@
 //! holds the argument-parsing and output-formatting code they share.
 #![warn(missing_docs)]
 
+pub mod calib_args;
+pub mod calib_cli;
 pub mod flash_args;
 pub mod flash_cli;
 pub mod gpio_cli;


### PR DESCRIPTION
## Summary

Ports `airspy_calibrate.c` — the last M5 tool: read or rewrite the calibration record (magic + epoch timestamp + ppb correction) stored at flash offset 0x20000 / sector 2.

**Layout** — `airspy_tools::calib_cli` holds the unit-tested logic: the `AIRSPY_FLASH_CALIB_OFFSET`/`AIRSPY_FLASH_CALIB_HEADER` constants, the 12-byte `airspy_calib_t` little-endian round-trip, header validity, and the `%04d/%02d/%02d %02d:%02d:%02d` localtime format (tested on a fixed naive datetime, TZ-independent). `calib_args` holds the clap command per the Lizard char-literal pattern — all functions verified locally at their true NLOC. The binary keeps C's flow: `-r` reads and displays; `-w` erases sector 2, prints the fresh record, then writes it. Kept faithful: this is the **only tool without `-s`**, and its distinct `Failed to open airspy device.` open-failure message.

## Deviations (per project policy)

1. **`-w` requires `--force`** — calibration writes are explicitly named by the repo's destructive-operations rule; the gate fires before the device opens, reads untouched. (Third use of the pattern after #64/#66.)
2. **Strict ppb parsing**: C's `atoi` silently turned garbage into 0 ppb and `12abc` into 12 — then wrote it to flash. The clap `i32` parser rejects both (tested), with `allow_negative_numbers` for getopt's native `-w -1500`.
3. **Unprogrammed-record warning**: C displays whatever it read (erased flash = 0xFF garbage timestamps); the read path warns on stderr when the `0xCA1B0001` magic is absent, while the display itself stays C-faithful.

## Testing

5 new unit tests (61 tools-lib; 180 workspace-wide). fmt/clippy (`-D warnings`, all features)/doc (`-D warnings`) clean, Lizard verified locally. Smoke-tested exclusivity, the force gate, negative ppb parsing, and the open-failure path; live behavior lands in M6.

Closes #30. With this merged, every M5 tool is ported — the epic closes and M6 (hardware validation with the R2) is all that remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a calibration utility for reading and writing device calibration data stored in flash.
  * Added command-line options for reading calibration details or writing correction values, including negative values.
  * Displays calibration timestamps and correction values.
  * Requires explicit confirmation before writing calibration data.
  * Warns when calibration data has an invalid header and reports operation failures clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->