### PR TITLE
M6: device-gated hardware integration tests (#32)

### DIFF
--- a/crates/libairspy/tests/device.rs
+++ b/crates/libairspy/tests/device.rs
@@ -65,12 +65,28 @@ fn with_stall_guard<T: Send + 'static>(
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         let mut device = device;
-        let result = capture(&mut device);
+        // A panicking capture must surface as itself, not as a
+        // 30-second "stalled" timeout: catch it and re-raise on the
+        // test thread immediately.
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| capture(&mut device)));
         // A dropped receiver (timed-out test) makes this send a no-op.
-        let _ = tx.send((device, result));
+        let _ = tx.send(result.map(|value| (device, value)));
     });
-    rx.recv_timeout(STALL_TIMEOUT)
-        .expect("device stalled: capture did not finish within STALL_TIMEOUT")
+    // On a true stall the worker stays blocked in the USB read and
+    // keeps the exclusive handle — nothing outside the kernel can
+    // cancel that read, so the honest behavior is a prompt, explicit
+    // failure. Later opens in the same run may then fail too; with
+    // hardware that wedged, replug the Airspy before rerunning.
+    let outcome = rx.recv_timeout(STALL_TIMEOUT).expect(
+        "device stalled: capture did not finish within STALL_TIMEOUT \
+         (the worker thread still holds the USB handle; replug the \
+         Airspy before rerunning)",
+    );
+    match outcome {
+        Ok(pair) => pair,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
 }
 
 /// Pull a handful of transfers in the device's current configuration,

--- a/crates/libairspy/tests/device.rs
+++ b/crates/libairspy/tests/device.rs
@@ -28,41 +28,73 @@ const TEST_FREQ_HZ: u32 = 100_000_000;
 /// several USB transfers without dragging the suite out.
 const SHORT_STREAM_BLOCKS: usize = 5;
 
-/// `airspy_set_lna_gain`'s clamp bound (14) in `airspy.c`.
+/// `airspy_set_lna_gain`'s clamp bound (`value > 14` in
+/// `airspyone_host` `libairspy/src/airspy.c`).
 const LNA_GAIN_MAX: u8 = 14;
-/// `airspy_set_mixer_gain` / `airspy_set_vga_gain` clamp bound (15).
+/// `airspy_set_mixer_gain`'s clamp bound (`value > 15` in
+/// `airspy.c`).
 const MIXER_GAIN_MAX: u8 = 15;
-/// See [`MIXER_GAIN_MAX`].
+/// `airspy_set_vga_gain`'s clamp bound (`value > 15` in `airspy.c`).
 const VGA_GAIN_MAX: u8 = 15;
-/// The 22-entry linearity/sensitivity tables in `airspy.c` accept
-/// indices 0..=21.
+/// The last index of `airspy.c`'s 22-entry
+/// `airspy_linearity_*_gains` / `airspy_sensitivity_*_gains` tables.
 const COMPOSITE_GAIN_MAX: u8 = 21;
 
-/// A 12-bit ADC word: unpacked RAW words carry values below this,
-/// leaving the top nibble of every 16-bit word zero; the packed
+/// One past the largest 12-bit ADC value — the sample width of
+/// `airspy.c`'s `unpack_samples` bitstream. Unpacked RAW words stay
+/// below this (top nibble of every 16-bit word zero); the packed
 /// 12-bit stream uses every nibble.
 const ADC_WORD_LIMIT: u16 = 1 << 12;
+
+/// How long a capture may run before the suite declares the device
+/// stalled. The library's reader tolerates bulk timeouts exactly as
+/// C's event loop does, so a silent device would otherwise block a
+/// blocking iterator read forever.
+const STALL_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Run a device-borrowing capture on a worker thread, failing the
+/// test if it does not finish within [`STALL_TIMEOUT`] — a silent
+/// device keeps the reader polling (C event-loop semantics), which
+/// would otherwise hang a blocking iterator read forever. The device
+/// moves through the worker and back so a timed-out capture cannot
+/// race a reopened handle.
+fn with_stall_guard<T: Send + 'static>(
+    device: Device,
+    capture: impl FnOnce(&mut Device) -> T + Send + 'static,
+) -> (Device, T) {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut device = device;
+        let result = capture(&mut device);
+        // A dropped receiver (timed-out test) makes this send a no-op.
+        let _ = tx.send((device, result));
+    });
+    rx.recv_timeout(STALL_TIMEOUT)
+        .expect("device stalled: capture did not finish within STALL_TIMEOUT")
+}
 
 /// Pull a handful of transfers in the device's current configuration,
 /// asserting each reports the expected latched sample type.
 fn capture_blocks(
-    device: &mut Device,
+    device: Device,
     expected_type: SampleType,
     count: usize,
-) -> Vec<SampleBlock> {
-    let mut blocks = Vec::new();
-    {
-        let iter = device.rx_blocks().expect("rx_blocks");
-        for transfer in iter.take(count) {
-            assert_eq!(
-                transfer.sample_type, expected_type,
-                "transfer reports the wrong sample type"
-            );
-            blocks.push(transfer.samples);
+) -> (Device, Vec<SampleBlock>) {
+    with_stall_guard(device, move |device| {
+        let mut blocks = Vec::new();
+        {
+            let iter = device.rx_blocks().expect("rx_blocks");
+            for transfer in iter.take(count) {
+                assert_eq!(
+                    transfer.sample_type, expected_type,
+                    "transfer reports the wrong sample type"
+                );
+                blocks.push(transfer.samples);
+            }
         }
-    }
-    assert!(!device.is_streaming(), "stream still live after drop");
-    blocks
+        assert!(!device.is_streaming(), "stream still live after drop");
+        blocks
+    })
 }
 
 /// Fraction of 16-bit words in a RAW block whose top nibble is used.
@@ -175,7 +207,8 @@ mod tests {
             SampleType::Raw,
         ] {
             device.set_sample_type(sample_type).expect("set type");
-            let blocks = capture_blocks(&mut device, sample_type, SHORT_STREAM_BLOCKS);
+            let (returned, blocks) = capture_blocks(device, sample_type, SHORT_STREAM_BLOCKS);
+            device = returned;
             assert_eq!(blocks.len(), SHORT_STREAM_BLOCKS, "{sample_type:?}");
             for block in &blocks {
                 let (len, finite) = match block {
@@ -202,7 +235,8 @@ mod tests {
         // Unpacked RAW: 12-bit ADC values in 16-bit words — every word
         // below ADC_WORD_LIMIT, top nibbles all zero.
         device.set_packing(false).expect("packing off");
-        let unpacked = capture_blocks(&mut device, SampleType::Raw, SHORT_STREAM_BLOCKS);
+        let (returned, unpacked) = capture_blocks(device, SampleType::Raw, SHORT_STREAM_BLOCKS);
+        device = returned;
         assert_eq!(unpacked.len(), SHORT_STREAM_BLOCKS);
         for block in &unpacked {
             let SampleBlock::Raw(bytes) = block else {
@@ -220,7 +254,8 @@ mod tests {
         // limit — this is what proves set_packing(true) took effect on
         // the wire (block byte counts are identical in both modes).
         device.set_packing(true).expect("packing on");
-        let packed = capture_blocks(&mut device, SampleType::Raw, SHORT_STREAM_BLOCKS);
+        let (returned, packed) = capture_blocks(device, SampleType::Raw, SHORT_STREAM_BLOCKS);
+        device = returned;
         assert_eq!(packed.len(), SHORT_STREAM_BLOCKS);
         for block in &packed {
             let SampleBlock::Raw(bytes) = block else {
@@ -250,10 +285,10 @@ mod tests {
         let rates = device.samplerates();
         let nominal = rates.first().copied().expect("a rate");
 
-        let mut dropped = 0u64;
-        let mut frames = 0u64;
         let started = Instant::now();
-        {
+        let (device, (dropped, frames)) = with_stall_guard(device, move |device| {
+            let mut dropped = 0u64;
+            let mut frames = 0u64;
             let iter = device.rx_blocks().expect("rx_blocks");
             for transfer in iter {
                 dropped += transfer.dropped_samples;
@@ -264,7 +299,9 @@ mod tests {
                     break;
                 }
             }
-        }
+            (dropped, frames)
+        });
+        drop(device);
         let elapsed = started.elapsed().as_secs_f64();
         // Frame counts over a few seconds sit far below 2^52.
         #[allow(clippy::cast_precision_loss)]
@@ -290,7 +327,8 @@ mod tests {
         device.set_freq(TEST_FREQ_HZ).expect("freq");
         device.set_sample_type(SampleType::Float32Iq).expect("type");
         for round in 0..3 {
-            let blocks = capture_blocks(&mut device, SampleType::Float32Iq, 2);
+            let (returned, blocks) = capture_blocks(device, SampleType::Float32Iq, 2);
+            device = returned;
             assert_eq!(blocks.len(), 2, "round {round}");
         }
     }

--- a/crates/libairspy/tests/device.rs
+++ b/crates/libairspy/tests/device.rs
@@ -28,201 +28,268 @@ const TEST_FREQ_HZ: u32 = 100_000_000;
 /// several USB transfers without dragging the suite out.
 const SHORT_STREAM_BLOCKS: usize = 5;
 
-#[test]
-#[ignore = "requires Airspy hardware"]
-fn enumerates_at_least_one_device() {
-    let serials = list_devices().expect("list_devices");
-    assert!(!serials.is_empty(), "no Airspy enumerated");
-    for serial in &serials {
-        println!("enumerated serial: 0x{serial:016X}");
-    }
-}
+/// `airspy_set_lna_gain`'s clamp bound (14) in `airspy.c`.
+const LNA_GAIN_MAX: u8 = 14;
+/// `airspy_set_mixer_gain` / `airspy_set_vga_gain` clamp bound (15).
+const MIXER_GAIN_MAX: u8 = 15;
+/// See [`MIXER_GAIN_MAX`].
+const VGA_GAIN_MAX: u8 = 15;
+/// The 22-entry linearity/sensitivity tables in `airspy.c` accept
+/// indices 0..=21.
+const COMPOSITE_GAIN_MAX: u8 = 21;
 
-#[test]
-#[ignore = "requires Airspy hardware"]
-fn identity_reads_match_an_airspy() {
-    let device = Device::open().expect("open");
-    let board_id = device.board_id().expect("board_id");
-    println!("board id: {board_id}");
-    assert_eq!(
-        BoardId::from_u8(board_id),
-        Some(BoardId::ProtoAirspy),
-        "unexpected board id {board_id}"
-    );
+/// A 12-bit ADC word: unpacked RAW words carry values below this,
+/// leaving the top nibble of every 16-bit word zero; the packed
+/// 12-bit stream uses every nibble.
+const ADC_WORD_LIMIT: u16 = 1 << 12;
 
-    let version = device.version_string().expect("version_string");
-    println!("firmware: {version}");
-    assert!(!version.is_empty());
-    assert!(version.contains("AirSpy"), "unexpected version: {version}");
-
-    let ids = device.partid_serialno().expect("partid_serialno");
-    println!(
-        "part id: 0x{:08X} 0x{:08X}, serial: 0x{:08X}{:08X}",
-        ids.part_id[0], ids.part_id[1], ids.serial_no[2], ids.serial_no[3]
-    );
-    assert_ne!(ids.serial_no, [0; 4], "serial reads as all zero");
-}
-
-#[test]
-#[ignore = "requires Airspy hardware"]
-fn samplerate_table_is_populated() {
-    let device = Device::open().expect("open");
-    let rates = device.samplerates();
-    println!("supported IQ rates: {rates:?}");
-    assert!(!rates.is_empty());
-    // Every known Airspy firmware advertises 10 MSPS; the R2 also
-    // lists 2.5 MSPS.
-    assert!(rates.contains(&10_000_000), "10 MSPS missing: {rates:?}");
-}
-
-#[test]
-#[ignore = "requires Airspy hardware"]
-fn control_surface_accepts_the_full_range() {
-    let mut device = Device::open().expect("open");
-    device.set_samplerate(0).expect("set_samplerate index 0");
-    device.set_freq(TEST_FREQ_HZ).expect("set_freq");
-
-    // Gain endpoints (clamping covered by unit tests; here the wire
-    // must accept the extremes).
-    device.set_lna_gain(0).expect("lna 0");
-    device.set_lna_gain(14).expect("lna max");
-    device.set_mixer_gain(0).expect("mixer 0");
-    device.set_mixer_gain(15).expect("mixer max");
-    device.set_vga_gain(0).expect("vga 0");
-    device.set_vga_gain(15).expect("vga max");
-    device.set_linearity_gain(10).expect("linearity");
-    device.set_sensitivity_gain(10).expect("sensitivity");
-    device.set_lna_agc(false).expect("lna agc off");
-    device.set_mixer_agc(false).expect("mixer agc off");
-    device.set_packing(false).expect("packing off");
-    // NOTE: set_rf_bias(true) is intentionally absent — see the
-    // module docs. Turning it off is safe regardless.
-    device.set_rf_bias(false).expect("bias off");
-}
-
-/// Pull a handful of blocks in the device's current configuration and
-/// return (blocks, total dropped samples).
-fn capture_blocks(device: &mut Device, count: usize) -> (Vec<SampleBlock>, u64) {
-    let mut dropped = 0;
+/// Pull a handful of transfers in the device's current configuration,
+/// asserting each reports the expected latched sample type.
+fn capture_blocks(
+    device: &mut Device,
+    expected_type: SampleType,
+    count: usize,
+) -> Vec<SampleBlock> {
     let mut blocks = Vec::new();
     {
         let iter = device.rx_blocks().expect("rx_blocks");
         for transfer in iter.take(count) {
-            dropped += transfer.dropped_samples;
+            assert_eq!(
+                transfer.sample_type, expected_type,
+                "transfer reports the wrong sample type"
+            );
             blocks.push(transfer.samples);
         }
     }
     assert!(!device.is_streaming(), "stream still live after drop");
-    (blocks, dropped)
+    blocks
 }
 
-#[test]
-#[ignore = "requires Airspy hardware"]
-fn streams_every_sample_type() {
-    let mut device = Device::open().expect("open");
-    device.set_samplerate(0).expect("rate");
-    device.set_freq(TEST_FREQ_HZ).expect("freq");
-
-    for sample_type in [
-        SampleType::Float32Iq,
-        SampleType::Float32Real,
-        SampleType::Int16Iq,
-        SampleType::Int16Real,
-        SampleType::Uint16Real,
-        SampleType::Raw,
-    ] {
-        device.set_sample_type(sample_type).expect("set type");
-        let (blocks, _) = capture_blocks(&mut device, SHORT_STREAM_BLOCKS);
-        assert_eq!(blocks.len(), SHORT_STREAM_BLOCKS, "{sample_type:?}");
-        for block in &blocks {
-            let (len, finite) = match block {
-                SampleBlock::Float32(s) => (s.len(), s.iter().all(|v| v.is_finite())),
-                SampleBlock::Int16(s) => (s.len(), true),
-                SampleBlock::Uint16(s) => (s.len(), true),
-                SampleBlock::Raw(s) => (s.len(), true),
-            };
-            assert!(len > 0, "{sample_type:?}: empty block");
-            assert!(finite, "{sample_type:?}: non-finite samples");
-        }
-        println!("{sample_type:?}: {} blocks OK", blocks.len());
-    }
-}
-
-#[test]
-#[ignore = "requires Airspy hardware"]
-fn packed_raw_capture_streams() {
-    let mut device = Device::open().expect("open");
-    device.set_samplerate(0).expect("rate");
-    device.set_freq(TEST_FREQ_HZ).expect("freq");
-    device.set_sample_type(SampleType::Raw).expect("type");
-    device.set_packing(true).expect("packing on");
-    let (blocks, _) = capture_blocks(&mut device, SHORT_STREAM_BLOCKS);
-    assert_eq!(blocks.len(), SHORT_STREAM_BLOCKS);
-    for block in &blocks {
-        let SampleBlock::Raw(bytes) = block else {
-            unreachable!("expected raw block, got {block:?}");
-        };
-        assert!(!bytes.is_empty());
-    }
-    device.set_packing(false).expect("packing off again");
-}
-
-#[test]
-#[ignore = "requires Airspy hardware"]
-fn sustained_capture_has_no_drops() {
-    const CAPTURE_SECONDS: u64 = 3;
-
-    let mut device = Device::open().expect("open");
-    device.set_samplerate(0).expect("rate (index 0 = fastest)");
-    device.set_freq(TEST_FREQ_HZ).expect("freq");
-    device
-        .set_sample_type(SampleType::Int16Iq)
-        .expect("int16 iq");
-
-    let rates = device.samplerates();
-    let nominal = rates.first().copied().expect("a rate");
-
-    let mut dropped = 0u64;
-    let mut frames = 0u64;
-    let started = Instant::now();
-    {
-        let iter = device.rx_blocks().expect("rx_blocks");
-        for transfer in iter {
-            dropped += transfer.dropped_samples;
-            if let SampleBlock::Int16(samples) = &transfer.samples {
-                frames += samples.len() as u64 / 2;
-            }
-            if started.elapsed() >= Duration::from_secs(CAPTURE_SECONDS) {
-                break;
-            }
-        }
-    }
-    let elapsed = started.elapsed().as_secs_f64();
-    // Frame counts over a few seconds sit far below 2^52.
+/// Fraction of 16-bit words in a RAW block whose top nibble is used.
+fn high_nibble_ratio(bytes: &[u8]) -> f64 {
+    let words: Vec<u16> = bytes
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    let high = words.iter().filter(|w| **w >= ADC_WORD_LIMIT).count();
     #[allow(clippy::cast_precision_loss)]
-    let rate = frames as f64 / elapsed;
-    println!(
-        "sustained: {frames} IQ frames in {elapsed:.2}s = {:.3} MSPS (nominal {:.1}), dropped {dropped}",
-        rate / 1e6,
-        f64::from(nominal) / 1e6
-    );
-    assert_eq!(dropped, 0, "dropped samples during sustained capture");
-    // Within 10% of nominal proves the pipeline keeps up.
-    assert!(
-        rate > f64::from(nominal) * 0.9,
-        "throughput {rate} too far below nominal {nominal}"
-    );
+    let ratio = high as f64 / words.len().max(1) as f64;
+    ratio
 }
 
-#[test]
-#[ignore = "requires Airspy hardware"]
-fn stream_restarts_cleanly() {
-    let mut device = Device::open().expect("open");
-    device.set_samplerate(0).expect("rate");
-    device.set_freq(TEST_FREQ_HZ).expect("freq");
-    device.set_sample_type(SampleType::Float32Iq).expect("type");
-    for round in 0..3 {
-        let (blocks, _) = capture_blocks(&mut device, 2);
-        assert_eq!(blocks.len(), 2, "round {round}");
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "requires Airspy hardware"]
+    fn enumerates_at_least_one_device() {
+        let serials = list_devices().expect("list_devices");
+        assert!(!serials.is_empty(), "no Airspy enumerated");
+        for serial in &serials {
+            println!("enumerated serial: 0x{serial:016X}");
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Airspy hardware"]
+    fn identity_reads_match_an_airspy() {
+        let device = Device::open().expect("open");
+        let board_id = device.board_id().expect("board_id");
+        println!("board id: {board_id}");
+        assert_eq!(
+            BoardId::from_u8(board_id),
+            Some(BoardId::ProtoAirspy),
+            "unexpected board id {board_id}"
+        );
+
+        let version = device.version_string().expect("version_string");
+        println!("firmware: {version}");
+        assert!(!version.is_empty());
+        assert!(version.contains("AirSpy"), "unexpected version: {version}");
+
+        let ids = device.partid_serialno().expect("partid_serialno");
+        println!(
+            "part id: 0x{:08X} 0x{:08X}, serial: 0x{:08X}{:08X}",
+            ids.part_id[0], ids.part_id[1], ids.serial_no[2], ids.serial_no[3]
+        );
+        assert_ne!(ids.serial_no, [0; 4], "serial reads as all zero");
+    }
+
+    #[test]
+    #[ignore = "requires Airspy hardware"]
+    fn samplerate_table_is_populated() {
+        let device = Device::open().expect("open");
+        let rates = device.samplerates();
+        println!("supported IQ rates: {rates:?}");
+        assert!(!rates.is_empty());
+        // Every known Airspy firmware advertises 10 MSPS; the R2 also
+        // lists 2.5 MSPS.
+        assert!(rates.contains(&10_000_000), "10 MSPS missing: {rates:?}");
+    }
+
+    #[test]
+    #[ignore = "requires Airspy hardware"]
+    fn control_surface_accepts_the_full_range() {
+        let mut device = Device::open().expect("open");
+        device.set_samplerate(0).expect("set_samplerate index 0");
+        device.set_freq(TEST_FREQ_HZ).expect("set_freq");
+
+        // Gain endpoints (clamping covered by unit tests; here the wire
+        // must accept the extremes).
+        device.set_lna_gain(0).expect("lna 0");
+        device.set_lna_gain(LNA_GAIN_MAX).expect("lna max");
+        device.set_mixer_gain(0).expect("mixer 0");
+        device.set_mixer_gain(MIXER_GAIN_MAX).expect("mixer max");
+        device.set_vga_gain(0).expect("vga 0");
+        device.set_vga_gain(VGA_GAIN_MAX).expect("vga max");
+        device.set_linearity_gain(0).expect("linearity 0");
+        device
+            .set_linearity_gain(COMPOSITE_GAIN_MAX)
+            .expect("linearity max");
+        device.set_sensitivity_gain(0).expect("sensitivity 0");
+        device
+            .set_sensitivity_gain(COMPOSITE_GAIN_MAX)
+            .expect("sensitivity max");
+        device.set_lna_agc(false).expect("lna agc off");
+        device.set_mixer_agc(false).expect("mixer agc off");
+        device.set_packing(false).expect("packing off");
+        // NOTE: set_rf_bias(true) is intentionally absent — see the
+        // module docs. Turning it off is safe regardless.
+        device.set_rf_bias(false).expect("bias off");
+    }
+
+    #[test]
+    #[ignore = "requires Airspy hardware"]
+    fn streams_every_sample_type() {
+        let mut device = Device::open().expect("open");
+        device.set_samplerate(0).expect("rate");
+        device.set_freq(TEST_FREQ_HZ).expect("freq");
+
+        for sample_type in [
+            SampleType::Float32Iq,
+            SampleType::Float32Real,
+            SampleType::Int16Iq,
+            SampleType::Int16Real,
+            SampleType::Uint16Real,
+            SampleType::Raw,
+        ] {
+            device.set_sample_type(sample_type).expect("set type");
+            let blocks = capture_blocks(&mut device, sample_type, SHORT_STREAM_BLOCKS);
+            assert_eq!(blocks.len(), SHORT_STREAM_BLOCKS, "{sample_type:?}");
+            for block in &blocks {
+                let (len, finite) = match block {
+                    SampleBlock::Float32(s) => (s.len(), s.iter().all(|v| v.is_finite())),
+                    SampleBlock::Int16(s) => (s.len(), true),
+                    SampleBlock::Uint16(s) => (s.len(), true),
+                    SampleBlock::Raw(s) => (s.len(), true),
+                };
+                assert!(len > 0, "{sample_type:?}: empty block");
+                assert!(finite, "{sample_type:?}: non-finite samples");
+            }
+            println!("{sample_type:?}: {} blocks OK", blocks.len());
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Airspy hardware"]
+    fn packed_raw_capture_streams() {
+        let mut device = Device::open().expect("open");
+        device.set_samplerate(0).expect("rate");
+        device.set_freq(TEST_FREQ_HZ).expect("freq");
+        device.set_sample_type(SampleType::Raw).expect("type");
+
+        // Unpacked RAW: 12-bit ADC values in 16-bit words — every word
+        // below ADC_WORD_LIMIT, top nibbles all zero.
+        device.set_packing(false).expect("packing off");
+        let unpacked = capture_blocks(&mut device, SampleType::Raw, SHORT_STREAM_BLOCKS);
+        for block in &unpacked {
+            let SampleBlock::Raw(bytes) = block else {
+                unreachable!("expected raw block, got {block:?}");
+            };
+            assert!(!bytes.is_empty());
+            assert!(
+                high_nibble_ratio(bytes) == 0.0,
+                "unpacked RAW words exceed 12 bits"
+            );
+        }
+
+        // Packed RAW: a continuous 12-bit stream uses every nibble, so a
+        // substantial share of word-aligned reads land above the 12-bit
+        // limit — this is what proves set_packing(true) took effect on
+        // the wire (block byte counts are identical in both modes).
+        device.set_packing(true).expect("packing on");
+        let packed = capture_blocks(&mut device, SampleType::Raw, SHORT_STREAM_BLOCKS);
+        for block in &packed {
+            let SampleBlock::Raw(bytes) = block else {
+                unreachable!("expected raw block, got {block:?}");
+            };
+            assert!(!bytes.is_empty());
+            assert!(
+                high_nibble_ratio(bytes) > 0.05,
+                "packed RAW stream looks unpacked (top nibbles unused)"
+            );
+        }
+        device.set_packing(false).expect("packing off again");
+    }
+
+    #[test]
+    #[ignore = "requires Airspy hardware"]
+    fn sustained_capture_has_no_drops() {
+        const CAPTURE_SECONDS: u64 = 3;
+
+        let mut device = Device::open().expect("open");
+        device.set_samplerate(0).expect("rate (index 0 = fastest)");
+        device.set_freq(TEST_FREQ_HZ).expect("freq");
+        device
+            .set_sample_type(SampleType::Int16Iq)
+            .expect("int16 iq");
+
+        let rates = device.samplerates();
+        let nominal = rates.first().copied().expect("a rate");
+
+        let mut dropped = 0u64;
+        let mut frames = 0u64;
+        let started = Instant::now();
+        {
+            let iter = device.rx_blocks().expect("rx_blocks");
+            for transfer in iter {
+                dropped += transfer.dropped_samples;
+                if let SampleBlock::Int16(samples) = &transfer.samples {
+                    frames += samples.len() as u64 / 2;
+                }
+                if started.elapsed() >= Duration::from_secs(CAPTURE_SECONDS) {
+                    break;
+                }
+            }
+        }
+        let elapsed = started.elapsed().as_secs_f64();
+        // Frame counts over a few seconds sit far below 2^52.
+        #[allow(clippy::cast_precision_loss)]
+        let rate = frames as f64 / elapsed;
+        println!(
+            "sustained: {frames} IQ frames in {elapsed:.2}s = {:.3} MSPS (nominal {:.1}), dropped {dropped}",
+            rate / 1e6,
+            f64::from(nominal) / 1e6
+        );
+        assert_eq!(dropped, 0, "dropped samples during sustained capture");
+        // Within 10% of nominal proves the pipeline keeps up.
+        assert!(
+            rate > f64::from(nominal) * 0.9,
+            "throughput {rate} too far below nominal {nominal}"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires Airspy hardware"]
+    fn stream_restarts_cleanly() {
+        let mut device = Device::open().expect("open");
+        device.set_samplerate(0).expect("rate");
+        device.set_freq(TEST_FREQ_HZ).expect("freq");
+        device.set_sample_type(SampleType::Float32Iq).expect("type");
+        for round in 0..3 {
+            let blocks = capture_blocks(&mut device, SampleType::Float32Iq, 2);
+            assert_eq!(blocks.len(), 2, "round {round}");
+        }
     }
 }

--- a/crates/libairspy/tests/device.rs
+++ b/crates/libairspy/tests/device.rs
@@ -211,11 +211,21 @@ mod tests {
             device = returned;
             assert_eq!(blocks.len(), SHORT_STREAM_BLOCKS, "{sample_type:?}");
             for block in &blocks {
-                let (len, finite) = match block {
-                    SampleBlock::Float32(s) => (s.len(), s.iter().all(|v| v.is_finite())),
-                    SampleBlock::Int16(s) => (s.len(), true),
-                    SampleBlock::Uint16(s) => (s.len(), true),
-                    SampleBlock::Raw(s) => (s.len(), true),
+                // Each sample type must arrive in its own block
+                // variant — the conversion dispatch, not just the
+                // latched metadata.
+                let (len, finite) = match (sample_type, block) {
+                    (SampleType::Float32Iq | SampleType::Float32Real, SampleBlock::Float32(s)) => {
+                        (s.len(), s.iter().all(|v| v.is_finite()))
+                    }
+                    (SampleType::Int16Iq | SampleType::Int16Real, SampleBlock::Int16(s)) => {
+                        (s.len(), true)
+                    }
+                    (SampleType::Uint16Real, SampleBlock::Uint16(s)) => (s.len(), true),
+                    (SampleType::Raw, SampleBlock::Raw(s)) => (s.len(), true),
+                    (_, other) => {
+                        unreachable!("{sample_type:?} delivered the wrong variant: {other:?}")
+                    }
                 };
                 assert!(len > 0, "{sample_type:?}: empty block");
                 assert!(finite, "{sample_type:?}: non-finite samples");

--- a/crates/libairspy/tests/device.rs
+++ b/crates/libairspy/tests/device.rs
@@ -203,6 +203,7 @@ mod tests {
         // below ADC_WORD_LIMIT, top nibbles all zero.
         device.set_packing(false).expect("packing off");
         let unpacked = capture_blocks(&mut device, SampleType::Raw, SHORT_STREAM_BLOCKS);
+        assert_eq!(unpacked.len(), SHORT_STREAM_BLOCKS);
         for block in &unpacked {
             let SampleBlock::Raw(bytes) = block else {
                 unreachable!("expected raw block, got {block:?}");
@@ -220,6 +221,7 @@ mod tests {
         // the wire (block byte counts are identical in both modes).
         device.set_packing(true).expect("packing on");
         let packed = capture_blocks(&mut device, SampleType::Raw, SHORT_STREAM_BLOCKS);
+        assert_eq!(packed.len(), SHORT_STREAM_BLOCKS);
         for block in &packed {
             let SampleBlock::Raw(bytes) = block else {
                 unreachable!("expected raw block, got {block:?}");

--- a/crates/libairspy/tests/device.rs
+++ b/crates/libairspy/tests/device.rs
@@ -1,0 +1,228 @@
+//! Device-gated integration tests — the M6 hardware-validation suite.
+//!
+//! Every test here talks to a real Airspy over USB and is therefore
+//! `#[ignore]`d so CI (and any hardware-free machine) stays green.
+//! With an Airspy connected, run them single-threaded — the tests
+//! share one physical device and each opens it exclusively:
+//!
+//! ```sh
+//! cargo test -p libairspy-rs --test device -- --ignored --test-threads=1
+//! ```
+//!
+//! The bias tee is deliberately never enabled: these tests cannot
+//! know what is attached to the antenna port, and 4.5 V on the wrong
+//! hardware is destructive.
+
+use std::time::{Duration, Instant};
+
+use libairspy_rs::commands::{BoardId, SampleType};
+use libairspy_rs::reader::SampleBlock;
+use libairspy_rs::{Device, list_devices};
+
+/// A tuning target for the streaming tests. The content of the
+/// spectrum does not matter (no antenna may be attached); 100 MHz is
+/// simply a valid, mid-band frequency.
+const TEST_FREQ_HZ: u32 = 100_000_000;
+
+/// Blocks to pull for the short per-type streams — enough to cross
+/// several USB transfers without dragging the suite out.
+const SHORT_STREAM_BLOCKS: usize = 5;
+
+#[test]
+#[ignore = "requires Airspy hardware"]
+fn enumerates_at_least_one_device() {
+    let serials = list_devices().expect("list_devices");
+    assert!(!serials.is_empty(), "no Airspy enumerated");
+    for serial in &serials {
+        println!("enumerated serial: 0x{serial:016X}");
+    }
+}
+
+#[test]
+#[ignore = "requires Airspy hardware"]
+fn identity_reads_match_an_airspy() {
+    let device = Device::open().expect("open");
+    let board_id = device.board_id().expect("board_id");
+    println!("board id: {board_id}");
+    assert_eq!(
+        BoardId::from_u8(board_id),
+        Some(BoardId::ProtoAirspy),
+        "unexpected board id {board_id}"
+    );
+
+    let version = device.version_string().expect("version_string");
+    println!("firmware: {version}");
+    assert!(!version.is_empty());
+    assert!(version.contains("AirSpy"), "unexpected version: {version}");
+
+    let ids = device.partid_serialno().expect("partid_serialno");
+    println!(
+        "part id: 0x{:08X} 0x{:08X}, serial: 0x{:08X}{:08X}",
+        ids.part_id[0], ids.part_id[1], ids.serial_no[2], ids.serial_no[3]
+    );
+    assert_ne!(ids.serial_no, [0; 4], "serial reads as all zero");
+}
+
+#[test]
+#[ignore = "requires Airspy hardware"]
+fn samplerate_table_is_populated() {
+    let device = Device::open().expect("open");
+    let rates = device.samplerates();
+    println!("supported IQ rates: {rates:?}");
+    assert!(!rates.is_empty());
+    // Every known Airspy firmware advertises 10 MSPS; the R2 also
+    // lists 2.5 MSPS.
+    assert!(rates.contains(&10_000_000), "10 MSPS missing: {rates:?}");
+}
+
+#[test]
+#[ignore = "requires Airspy hardware"]
+fn control_surface_accepts_the_full_range() {
+    let mut device = Device::open().expect("open");
+    device.set_samplerate(0).expect("set_samplerate index 0");
+    device.set_freq(TEST_FREQ_HZ).expect("set_freq");
+
+    // Gain endpoints (clamping covered by unit tests; here the wire
+    // must accept the extremes).
+    device.set_lna_gain(0).expect("lna 0");
+    device.set_lna_gain(14).expect("lna max");
+    device.set_mixer_gain(0).expect("mixer 0");
+    device.set_mixer_gain(15).expect("mixer max");
+    device.set_vga_gain(0).expect("vga 0");
+    device.set_vga_gain(15).expect("vga max");
+    device.set_linearity_gain(10).expect("linearity");
+    device.set_sensitivity_gain(10).expect("sensitivity");
+    device.set_lna_agc(false).expect("lna agc off");
+    device.set_mixer_agc(false).expect("mixer agc off");
+    device.set_packing(false).expect("packing off");
+    // NOTE: set_rf_bias(true) is intentionally absent — see the
+    // module docs. Turning it off is safe regardless.
+    device.set_rf_bias(false).expect("bias off");
+}
+
+/// Pull a handful of blocks in the device's current configuration and
+/// return (blocks, total dropped samples).
+fn capture_blocks(device: &mut Device, count: usize) -> (Vec<SampleBlock>, u64) {
+    let mut dropped = 0;
+    let mut blocks = Vec::new();
+    {
+        let iter = device.rx_blocks().expect("rx_blocks");
+        for transfer in iter.take(count) {
+            dropped += transfer.dropped_samples;
+            blocks.push(transfer.samples);
+        }
+    }
+    assert!(!device.is_streaming(), "stream still live after drop");
+    (blocks, dropped)
+}
+
+#[test]
+#[ignore = "requires Airspy hardware"]
+fn streams_every_sample_type() {
+    let mut device = Device::open().expect("open");
+    device.set_samplerate(0).expect("rate");
+    device.set_freq(TEST_FREQ_HZ).expect("freq");
+
+    for sample_type in [
+        SampleType::Float32Iq,
+        SampleType::Float32Real,
+        SampleType::Int16Iq,
+        SampleType::Int16Real,
+        SampleType::Uint16Real,
+        SampleType::Raw,
+    ] {
+        device.set_sample_type(sample_type).expect("set type");
+        let (blocks, _) = capture_blocks(&mut device, SHORT_STREAM_BLOCKS);
+        assert_eq!(blocks.len(), SHORT_STREAM_BLOCKS, "{sample_type:?}");
+        for block in &blocks {
+            let (len, finite) = match block {
+                SampleBlock::Float32(s) => (s.len(), s.iter().all(|v| v.is_finite())),
+                SampleBlock::Int16(s) => (s.len(), true),
+                SampleBlock::Uint16(s) => (s.len(), true),
+                SampleBlock::Raw(s) => (s.len(), true),
+            };
+            assert!(len > 0, "{sample_type:?}: empty block");
+            assert!(finite, "{sample_type:?}: non-finite samples");
+        }
+        println!("{sample_type:?}: {} blocks OK", blocks.len());
+    }
+}
+
+#[test]
+#[ignore = "requires Airspy hardware"]
+fn packed_raw_capture_streams() {
+    let mut device = Device::open().expect("open");
+    device.set_samplerate(0).expect("rate");
+    device.set_freq(TEST_FREQ_HZ).expect("freq");
+    device.set_sample_type(SampleType::Raw).expect("type");
+    device.set_packing(true).expect("packing on");
+    let (blocks, _) = capture_blocks(&mut device, SHORT_STREAM_BLOCKS);
+    assert_eq!(blocks.len(), SHORT_STREAM_BLOCKS);
+    for block in &blocks {
+        let SampleBlock::Raw(bytes) = block else {
+            unreachable!("expected raw block, got {block:?}");
+        };
+        assert!(!bytes.is_empty());
+    }
+    device.set_packing(false).expect("packing off again");
+}
+
+#[test]
+#[ignore = "requires Airspy hardware"]
+fn sustained_capture_has_no_drops() {
+    const CAPTURE_SECONDS: u64 = 3;
+
+    let mut device = Device::open().expect("open");
+    device.set_samplerate(0).expect("rate (index 0 = fastest)");
+    device.set_freq(TEST_FREQ_HZ).expect("freq");
+    device
+        .set_sample_type(SampleType::Int16Iq)
+        .expect("int16 iq");
+
+    let rates = device.samplerates();
+    let nominal = rates.first().copied().expect("a rate");
+
+    let mut dropped = 0u64;
+    let mut frames = 0u64;
+    let started = Instant::now();
+    {
+        let iter = device.rx_blocks().expect("rx_blocks");
+        for transfer in iter {
+            dropped += transfer.dropped_samples;
+            if let SampleBlock::Int16(samples) = &transfer.samples {
+                frames += samples.len() as u64 / 2;
+            }
+            if started.elapsed() >= Duration::from_secs(CAPTURE_SECONDS) {
+                break;
+            }
+        }
+    }
+    let elapsed = started.elapsed().as_secs_f64();
+    // Frame counts over a few seconds sit far below 2^52.
+    #[allow(clippy::cast_precision_loss)]
+    let rate = frames as f64 / elapsed;
+    println!(
+        "sustained: {frames} IQ frames in {elapsed:.2}s = {:.3} MSPS (nominal {:.1}), dropped {dropped}",
+        rate / 1e6,
+        f64::from(nominal) / 1e6
+    );
+    assert_eq!(dropped, 0, "dropped samples during sustained capture");
+    // Within 10% of nominal proves the pipeline keeps up.
+    assert!(
+        rate > f64::from(nominal) * 0.9,
+        "throughput {rate} too far below nominal {nominal}"
+    );
+}
+
+#[test]
+#[ignore = "requires Airspy hardware"]
+fn stream_restarts_cleanly() {
+    let mut device = Device::open().expect("open");
+    device.set_samplerate(0).expect("rate");
+    device.set_freq(TEST_FREQ_HZ).expect("freq");
+    device.set_sample_type(SampleType::Float32Iq).expect("type");
+    for round in 0..3 {
+        let (blocks, _) = capture_blocks(&mut device, 2);
+        assert_eq!(blocks.len(), 2, "round {round}");
+    }
+}


### PR DESCRIPTION
## Summary

The M6 hardware-validation suite: eight `#[ignore]`d integration tests in `crates/libairspy/tests/device.rs`. They compile everywhere (CI stays hardware-free and green) and run only on request with an Airspy attached:

```sh
cargo test -p libairspy-rs --test device -- --ignored --test-threads=1
```

Single-threaded because the tests share one physical device, each opening it exclusively.

**Coverage:**
1. `enumerates_at_least_one_device` — `list_devices` returns a serial.
2. `identity_reads_match_an_airspy` — board id (`AIRSPY`), firmware version string, part id + serial (printed for the #31 record).
3. `samplerate_table_is_populated` — firmware table read; 10 MSPS present.
4. `control_surface_accepts_the_full_range` — freq, rate, every gain at its range endpoints, AGCs, packing, bias-off.
5. `streams_every_sample_type` — all six sample types deliver non-empty (and float-finite) blocks.
6. `packed_raw_capture_streams` — 12-bit packing on the wire.
7. `sustained_capture_has_no_drops` — 3 s at the fastest rate: **zero** dropped samples and ≥90% of nominal throughput (the pipeline keep-up proof).
8. `stream_restarts_cleanly` — three start/stop cycles.

**Safety**: the bias tee is deliberately never enabled — the suite cannot know what is attached to the antenna port; only the safe `set_rf_bias(false)` is exercised. Documented in the module header.

Closes #32. This is prep for #31: once the R2 is connected, the suite runs as-is and its printed identity/throughput output gets recorded in that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added an optional, hardware-based integration test suite for Airspy devices.
  - Covered device detection, identity, sample-rate discovery, control ranges, supported sample formats, and packed or unpacked raw streaming.
  - Added checks for sustained Int16 IQ throughput without dropped samples and repeated stream restarts.
  - Validated complete sample delivery and clean stream shutdown.
  - Tests run in single-threaded mode with the RF bias tee disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->