### PR TITLE
M6: hardware-shakedown fixes — SIGPIPE parity, -n exit message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "libairspy-rs",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tracing = "0.1"
 clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 ctrlc = { version = "3", features = ["termination"] }
+libc = "0.2"
 
 # Async-runtime integrations (optional, feature-gated in libairspy-rs;
 # same pattern as librtlsdr-rs)

--- a/crates/airspy-tools/Cargo.toml
+++ b/crates/airspy-tools/Cargo.toml
@@ -13,6 +13,7 @@ libairspy-rs.workspace = true
 clap.workspace = true
 chrono.workspace = true
 ctrlc.workspace = true
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/crates/airspy-tools/src/bin/airspy_calibrate.rs
+++ b/crates/airspy-tools/src/bin/airspy_calibrate.rs
@@ -79,6 +79,7 @@ fn write_calibration(device: &Device, correction_ppb: i32) -> Result<(), ()> {
 }
 
 fn main() {
+    airspy_tools::reset_sigpipe();
     let matches = calib_command().get_matches();
     let read = matches.get_flag("read");
     let write = matches.get_one::<i32>("write").copied();

--- a/crates/airspy-tools/src/bin/airspy_gpio.rs
+++ b/crates/airspy-tools/src/bin/airspy_gpio.rs
@@ -85,6 +85,7 @@ fn write_port_pin(device: &Device, port: GpioPort, pin: GpioPin, value: u8) -> R
 }
 
 fn main() {
+    airspy_tools::reset_sigpipe();
     let matches = gpio_command("airspy_gpio", "Read and write Airspy GPIO pins").get_matches();
 
     let Some(device) = open_from_matches(&matches) else {

--- a/crates/airspy-tools/src/bin/airspy_gpiodir.rs
+++ b/crates/airspy-tools/src/bin/airspy_gpiodir.rs
@@ -80,6 +80,7 @@ fn write_port_pin(device: &Device, port: GpioPort, pin: GpioPin, value: u8) -> R
 }
 
 fn main() {
+    airspy_tools::reset_sigpipe();
     let matches = gpio_command(
         "airspy_gpiodir",
         "Read and write Airspy GPIO pin directions",

--- a/crates/airspy-tools/src/bin/airspy_info.rs
+++ b/crates/airspy-tools/src/bin/airspy_info.rs
@@ -31,6 +31,7 @@ fn print_error(context: &str, err: &Error) {
 }
 
 fn main() {
+    airspy_tools::reset_sigpipe();
     let args = Args::parse();
 
     if let Some(serial) = args.serial_number {

--- a/crates/airspy-tools/src/bin/airspy_r820t.rs
+++ b/crates/airspy-tools/src/bin/airspy_r820t.rs
@@ -91,6 +91,7 @@ fn configure_registers(device: &Device) -> Result<(), Error> {
 }
 
 fn main() {
+    airspy_tools::reset_sigpipe();
     let matches = reg_command(
         "airspy_r820t",
         "Read and write the Airspy R820T tuner registers",

--- a/crates/airspy-tools/src/bin/airspy_rx.rs
+++ b/crates/airspy-tools/src/bin/airspy_rx.rs
@@ -93,6 +93,7 @@ fn on_transfer(
 }
 
 fn main() {
+    airspy_tools::reset_sigpipe();
     let args = Args::parse();
     let date_time = chrono::Local::now().format("%Y%m%d_%H%M%S").to_string();
     let config = match build_config(&args, &date_time) {
@@ -402,6 +403,15 @@ fn run(config: &Config) -> i32 {
     eprintln!("Stop with Ctrl-C");
     std::thread::sleep(LOOP_SLEEP);
     stream_loop(&device, &shared);
+    // C's is_streaming stays true after the callback stops the
+    // stream, so its loop always leaves via the budget branch and a
+    // completed -n capture prints "User cancel, exiting...". Our
+    // flag reflects the real stream state, so mirror C's message
+    // path explicitly when the byte budget drove the stop
+    // (hardware-verified against the C tool).
+    if lock_shared(&shared).remaining == Some(0) {
+        DO_EXIT.store(true, Ordering::SeqCst);
+    }
     print_summary(config, &shared, started);
 
     if let Err(err) = device.stop_rx() {

--- a/crates/airspy-tools/src/bin/airspy_si5351c.rs
+++ b/crates/airspy-tools/src/bin/airspy_si5351c.rs
@@ -128,6 +128,7 @@ fn dump_configuration(device: &Device) -> Result<(), Error> {
 }
 
 fn main() {
+    airspy_tools::reset_sigpipe();
     let matches = reg_command(
         "airspy_si5351c",
         "Read and write the Airspy si5351c clock generator registers",

--- a/crates/airspy-tools/src/bin/airspy_spiflash.rs
+++ b/crates/airspy-tools/src/bin/airspy_spiflash.rs
@@ -169,6 +169,7 @@ fn load_write_file(path: &str, address: u32) -> (Vec<u8>, u32) {
 }
 
 fn main() {
+    airspy_tools::reset_sigpipe();
     let matches = flash_command().get_matches();
     let address = matches.get_one::<u32>("address").copied().unwrap_or(0);
     let mut length = matches.get_one::<u32>("length").copied().unwrap_or(0);

--- a/crates/airspy-tools/src/lib.rs
+++ b/crates/airspy-tools/src/lib.rs
@@ -108,6 +108,22 @@ fn strtoull_whole(s: &str, base: u32) -> Option<u64> {
     })
 }
 
+/// Restore SIGPIPE's default disposition so a closed pipe kills the
+/// process silently (exit 141), exactly as the C tools die — Rust
+/// ignores SIGPIPE by default, which turned `airspy_si5351c -r |
+/// head` into a "failed printing to stdout: Broken pipe" panic.
+/// Call first in every binary's `main`.
+pub fn reset_sigpipe() {
+    // SAFETY: signal(SIGPIPE, SIG_DFL) only restores the process
+    // default disposition; it takes no user handler and runs before
+    // any other thread exists (first statement of main).
+    #[cfg(unix)]
+    #[allow(unsafe_code)]
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+}
+
 /// The shared `-s serial_number_64bits` argument every tool's C
 /// getopt table carries; callers needing a long form (only
 /// `airspy_si5351c.c` lists `--serial`) add it.

--- a/crates/airspy-tools/src/lib.rs
+++ b/crates/airspy-tools/src/lib.rs
@@ -108,11 +108,12 @@ fn strtoull_whole(s: &str, base: u32) -> Option<u64> {
     })
 }
 
-/// Restore SIGPIPE's default disposition so a closed pipe kills the
-/// process silently (exit 141), exactly as the C tools die — Rust
-/// ignores SIGPIPE by default, which turned `airspy_si5351c -r |
-/// head` into a "failed printing to stdout: Broken pipe" panic.
-/// Call first in every binary's `main`.
+/// On Unix, restore SIGPIPE's default disposition so a closed pipe
+/// kills the process silently (exit 141), exactly as the C tools
+/// die — Rust ignores SIGPIPE by default, which turned
+/// `airspy_si5351c -r | head` into a "failed printing to stdout:
+/// Broken pipe" panic. On non-Unix targets (no SIGPIPE semantics)
+/// this is a no-op. Call first in every binary's `main`.
 pub fn reset_sigpipe() {
     // SAFETY: signal(SIGPIPE, SIG_DFL) only restores the process
     // default disposition; it takes no user handler and runs before


### PR DESCRIPTION
## Summary

Two behavioral divergences surfaced during the first live-R2 validation pass (recorded on #31); both fixes are **hardware-verified against the C tools**.

1. **SIGPIPE parity (all eight tools)**: Rust ignores SIGPIPE by default, so `airspy_si5351c -r | head` panicked with `failed printing to stdout: Broken pipe (os error 32)` where the C tools die silently (exit 141). `airspy_tools::reset_sigpipe()` restores `SIG_DFL` as the first statement of every binary's `main` — the one narrowly scoped, documented `unsafe` block in the workspace (`signal(SIGPIPE, SIG_DFL)`, no user handler, before any thread exists; `#[cfg(unix)]`, no-op elsewhere). New `libc` dep, cargo-deny clean. Verified live: pipeline exit 141, no panic output.

2. **`-n` completion message (`airspy_rx`)**: a completed `-n` capture printed `Exiting...` where C prints `User cancel, exiting...` — C's `is_streaming` stays true after the callback stops the stream, so its loop always leaves via the budget branch; our flag truthfully reflects the self-stopped stream and took the other path. The binary now mirrors C's message path explicitly when the byte budget drove the stop (comment documents the mechanism). Verified live against `/usr/bin/airspy_rx`.

## Validation context

From the non-destructive #31 pass that found these: 8/8 device tests (9.965 MSPS sustained, 0 drops), every tool's read path byte-identical to C, LED/register/bias-T writes verified. Full record in the #31 comment.

180 workspace tests pass; fmt/clippy (`-D warnings`, all features)/doc/deny clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line tool behavior when output is piped to a process that closes the pipe.
  * Completed receiver captures now exit cleanly and display the expected completion message when a byte limit is reached.
  * Standardized signal handling across Airspy calibration, GPIO, device information, receiver, and hardware control tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->