### PR TITLE
docs: post-release README refresh with badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,53 @@
 # libairspy-rs
 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/76a82bc8c8124d67abc41efb5dd2b63b)](https://app.codacy.com/gh/jasonherald/libairspy-rs/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/76a82bc8c8124d67abc41efb5dd2b63b)](https://app.codacy.com/gh/jasonherald/libairspy-rs/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
+[![crates.io](https://img.shields.io/crates/v/libairspy-rs.svg)](https://crates.io/crates/libairspy-rs)
+[![docs.rs](https://img.shields.io/docsrs/libairspy-rs)](https://docs.rs/libairspy-rs)
+
 Pure-Rust port of [airspyone_host](https://github.com/airspy/airspyone_host) —
 USB driver and CLI tools for the Airspy R2 / Mini software-defined radio
 receivers, with no C library dependency (USB access via [`rusb`]).
 
-> **Status: under construction.** The C→Rust conversion is tracked in
-> [milestones](https://github.com/jasonherald/libairspy-rs/milestones) —
-> scaffold → device core → streaming → IQ conversion DSP → control
-> surface → tools → hardware validation. Releases are marked by
-> crates.io publishes; nothing is published yet.
+The port covers all implemented upstream functionality — the full
+`libairspy` control/streaming surface and all eight CLI tools — and is
+**validated against real hardware**: on an Airspy R2, the device test
+suite passes 8/8 with 9.965 MSPS sustained and zero dropped samples,
+and every tool's read output is byte-identical to C `airspy 1.0.10`.
+See [CHANGELOG.md](CHANGELOG.md) for the release history.
 
 ## Workspace layout
 
 | Crate | Package | License | What |
 |---|---|---|---|
-| `crates/libairspy` | [`libairspy-rs`] | BSD-3-Clause | The driver library: device management, vendor requests, bulk streaming, IQ conversion |
-| `crates/airspy-tools` | `airspy-tools` | GPL-2.0-or-later | CLI tools: `airspy_info`, `airspy_rx`, GPIO/register/flash utilities |
+| `crates/libairspy` | [`libairspy-rs`] | BSD-3-Clause AND MIT | The driver library: device management, vendor requests, bulk streaming, IQ conversion |
+| `crates/airspy-tools` | `airspy-tools` (unpublished) | GPL-2.0-or-later | The eight CLI tools: `airspy_info`, `airspy_rx`, `airspy_gpio`, `airspy_gpiodir`, `airspy_si5351c`, `airspy_r820t`, `airspy_spiflash`, `airspy_calibrate` |
 
 The two-crate split mirrors the upstream C tree's license boundary:
-libairspy is BSD-3-Clause, airspy-tools are GPL. See [NOTICE](NOTICE)
-for upstream attribution.
+libairspy is BSD-3-Clause (with the IQ converters ported from the last
+all-MIT upstream revision, hence `AND MIT`), airspy-tools are GPL. See
+[NOTICE](NOTICE) for upstream attribution.
 
 ## Design goals
 
 - **Faithful port.** Same USB wire behavior, same sample-pipeline
   semantics, DSP output validated against golden vectors generated from
-  the C converters (bit-exact for int16, bounded tolerance for float32).
+  the C converters (bit-exact for both int16 and float32). Tool output
+  is diffable against the C tools.
+- **More correct than upstream where it matters.** Genuine upstream
+  bugs (out-of-bounds accesses, silent numeric truncations, option
+  parsing mistakes) are fixed rather than propagated — each deviation
+  documented at its code site and in the changelog. Destructive tool
+  operations additionally require an explicit `--force`.
 - **Idiomatic surface.** RAII device handles instead of open/close
   pairs, `Result` instead of int codes, typed enums instead of raw
   bytes.
 - **Sync first-class, async opt-in.** Callback and `Iterator` sample
   delivery with no default dependencies; `tokio` and `smol` feature
   flags add `Stream` adapters (same pattern as [`librtlsdr-rs`]).
-- **No `unsafe`.** `unsafe_code = "deny"` workspace-wide.
+- **No `unsafe` in the library.** `unsafe_code = "deny"`
+  workspace-wide; the tools crate carries a single documented
+  exception (`signal(SIGPIPE, SIG_DFL)` for C-parity pipe behavior).
 
 ## Building
 
@@ -45,6 +60,12 @@ cargo test
 Requires `libusb-1.0` development headers (`libusb-1.0-0-dev` on
 Debian/Ubuntu) for `rusb`.
 
+With an Airspy attached, the device-gated integration tests run via:
+
+```sh
+cargo test -p libairspy-rs --test device --release -- --ignored --test-threads=1
+```
+
 ## Contributing
 
 Protected `main`; all changes land via feature-branch pull requests,
@@ -53,7 +74,7 @@ clippy (`-D warnings`), tests, cargo-deny, cargo-audit, and CodeQL.
 
 ## License
 
-- `libairspy-rs` crate: [BSD-3-Clause](crates/libairspy/LICENSE)
+- `libairspy-rs` crate: [BSD-3-Clause AND MIT](crates/libairspy/LICENSE)
 - `airspy-tools` crate: [GPL-2.0-or-later](crates/airspy-tools/LICENSE)
 
 [`rusb`]: https://crates.io/crates/rusb

--- a/crates/libairspy/README.md
+++ b/crates/libairspy/README.md
@@ -4,15 +4,21 @@ Pure-Rust port of [libairspy] — USB driver for the Airspy R2 / Mini
 software-defined radio receivers, with no C library dependency.
 
 A faithful port: USB wire behavior, sample-pipeline semantics, and DSP
-output match the original C library, behind an idiomatic Rust surface —
-RAII device handles, `Result`-based errors, typed enums, and
-`Iterator`/`Stream`-based sample delivery. Async integrations for tokio
-and smol are opt-in via feature flags; the sync path needs no features.
+output match the original C library (the IQ converters are bit-exact
+against golden vectors from the C implementation), behind an idiomatic
+Rust surface — RAII device handles, `Result`-based errors, typed enums,
+and callback/`Iterator`/`Stream` sample delivery. Async integrations
+for tokio and smol are opt-in via feature flags; the sync path needs no
+features and no `unsafe`.
 
-**Under construction** — the conversion is tracked in
-[milestones](https://github.com/jasonherald/libairspy-rs/milestones).
+Validated against real hardware: on an Airspy R2 the device-gated test
+suite passes 8/8, sustaining 9.965 MSPS with zero dropped samples.
+Genuine upstream bugs are fixed rather than propagated, each deviation
+documented at its code site.
 
-License: BSD-3-Clause, matching upstream libairspy. See the repository
+License: `BSD-3-Clause AND MIT` — BSD-3-Clause matching upstream
+libairspy, MIT for the IQ converters ported from the last all-MIT
+upstream revision. See the repository
 [NOTICE](https://github.com/jasonherald/libairspy-rs/blob/main/NOTICE)
 for upstream attribution.
 


### PR DESCRIPTION
## Summary

README catch-up now that v0.1.0 is out:

- **Badges**: the Codacy grade + coverage pair (same set as rtl-sdr) with the project token you provided, plus crates.io version and docs.rs badges — new additions that make sense now that the crate is published.
- **Status**: the "under construction / nothing is published yet" blurb becomes the released summary — all implemented upstream functionality ported, R2-validated (8/8 device tests, 9.965 MSPS zero-drop, byte-identical tool reads), with a changelog pointer.
- **Corrections while in there**: float32 converters are bit-exact (the old text said bounded tolerance — they exceeded expectations), license strings updated to `BSD-3-Clause AND MIT` with the MIT provenance explained, the tools row names all eight binaries, and the no-`unsafe` claim now notes the tools crate's single documented `SIGPIPE` exception.
- **Additions**: the deviation policy and `--force` gates in the design goals, and the device-test invocation in Building.
- The crates.io-facing `crates/libairspy/README.md` gets the matching refresh.

Docs-only; workspace tests and clippy verified unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded project and library documentation with current status, package links, workspace and CLI descriptions, and design goals.
  * Documented hardware validation results and hardware-gated integration-test commands.
  * Added details about IQ converter compatibility and callback, iterator, and stream sample delivery.
  * Documented optional Tokio and smol integrations, synchronous operation, upstream fixes, and supported functionality.
  * Corrected license information to BSD-3-Clause AND MIT.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->